### PR TITLE
Some improvments for USB power panic

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1595,12 +1595,11 @@ void setup()
           #ifdef DEBUG_UVLO_AUTOMATIC_RECOVER 
         puts_P(_N("Normal recovery!")); 
           #endif
-          if ( lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false) == LCD_LEFT_BUTTON_CHOICE) {
-              recover_print(0); 
-          } else { 
+          const uint8_t btn = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false);
+          if ( btn == LCD_LEFT_BUTTON_CHOICE) {
+              recover_print(0);
+          } else { // LCD_MIDDLE_BUTTON_CHOICE
               eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY); 
-              lcd_update_enable(true); 
-              lcd_update(2); 
               lcd_setstatuspgm(MSG_WELCOME); 
           } 
       }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1599,9 +1599,8 @@ void setup()
           if ( btn == LCD_LEFT_BUTTON_CHOICE) {
               recover_print(0);
           } else { // LCD_MIDDLE_BUTTON_CHOICE
-              eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY); 
-              lcd_setstatuspgm(MSG_WELCOME); 
-          } 
+              eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+          }
       }
   }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4105,9 +4105,16 @@ void process_commands()
         else if (code_seen_P(PSTR("FAN"))) { // PRUSA FAN
             printf_P(_N("E0:%d RPM\nPRN0:%d RPM\n"), 60*fan_speed[0], 60*fan_speed[1]);
         }
-        else if (code_seen_P(PSTR("uvlo"))) { // PRUSA uvlo
-            eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY); 
-            enquecommand_P(MSG_M24); 
+        else if (code_seen_P(PSTR("uvlo"))) // PRUSA uvlo
+        {
+            if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_SD)
+            {
+                // M24 - Start SD print
+                enquecommand_P(MSG_M24);
+            }
+
+            // Print is recovered, clear the recovery flag
+            eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
         }
 		else if (code_seen_P(PSTR("MMURES"))) // PRUSA MMURES
 		{

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4111,6 +4111,9 @@ void process_commands()
             {
                 // M24 - Start SD print
                 enquecommand_P(MSG_M24);
+
+            // Print is recovered, clear the recovery flag
+            eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
             }
             else if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_USB)
             {
@@ -4122,13 +4125,7 @@ void process_commands()
                 // Park the extruder to the side and don't resume the print
                 // we must assume that the host as not fully booted up at this point
                 lcd_pause_print();
-
-                // Used by M79 to differentiate from a normal pause
-                SetPrinterState(PrinterState::PowerPanicWaitingForHost);
             }
-
-            // Print is recovered, clear the recovery flag
-            eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
         }
 		else if (code_seen_P(PSTR("MMURES"))) // PRUSA MMURES
 		{
@@ -5987,15 +5984,12 @@ Sigma_Exit:
             }
         }
 
-        if (GetPrinterState() == PrinterState::PowerPanicWaitingForHost && print_job_timer.isPaused()) {
+        if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_USB && print_job_timer.isPaused()) {
             // The print is in a paused state. The print was recovered following a power panic
             // but up to this point the printer has been waiting for the M79 from the host
             // Send action to the host, so the host can resume the print. It is up to the host
             // to resume the print correctly.
             SERIAL_ECHOLNRPGM(MSG_OCTOPRINT_UVLO_RECOVERY_READY);
-
-            // Update the state so the action is not repeated again
-            SetPrinterState(PrinterState::IsHostPrinting);
         }
 
         break;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1595,11 +1595,15 @@ void setup()
           #ifdef DEBUG_UVLO_AUTOMATIC_RECOVER 
         puts_P(_N("Normal recovery!")); 
           #endif
-          const uint8_t btn = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false);
-          if ( btn == LCD_LEFT_BUTTON_CHOICE) {
-              recover_print(0);
-          } else { // LCD_MIDDLE_BUTTON_CHOICE
-              eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+          if (eeprom_read_byte((uint8_t*)EEPROM_UVLO) == PowerPanic::PRINT_TYPE_USB) {
+            recover_print(0);
+          } else {
+              const uint8_t btn = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false);
+              if ( btn == LCD_LEFT_BUTTON_CHOICE) {
+                  recover_print(0);
+            } else { // LCD_MIDDLE_BUTTON_CHOICE
+                  eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+            }
           }
       }
   }

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -8,6 +8,7 @@
 #include "messages.h"
 #include "language.h"
 #include "stopwatch.h"
+#include "power_panic.h"
 
 // Reserve BUFSIZE lines of length MAX_CMD_SIZE plus CMDBUFFER_RESERVE_FRONT.
 char cmdbuffer[BUFSIZE * (MAX_CMD_SIZE + 1) + CMDBUFFER_RESERVE_FRONT];
@@ -483,6 +484,7 @@ void get_command()
         if ((*cmd_start == 'G') && (GetPrinterState() != PrinterState::IsSDPrinting)) {
             usb_timer.start();
             SetPrinterState(PrinterState::IsHostPrinting); //set printer state busy printing to hide LCD menu while USB printing
+            eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
         }
         if (allow_when_stopped == false && Stopped == true) {
             // Stopped can be set either during error states (thermal error: cannot continue), or

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -233,6 +233,7 @@ const char MSG_OCTOPRINT_CANCEL[] PROGMEM_N1 = "// action:cancel"; ////
 const char MSG_OCTOPRINT_READY[] PROGMEM_N1 = "// action:ready"; ////
 const char MSG_OCTOPRINT_NOT_READY[] PROGMEM_N1 = "// action:not_ready"; ////
 const char MSG_OCTOPRINT_START[] PROGMEM_N1 = "// action:start"; ////
+const char MSG_OCTOPRINT_UVLO_RECOVERY_READY[] PROGMEM_N1 = "// action:uvlo_recovery_ready"; ////
 const char MSG_FANCHECK_HOTEND[] PROGMEM_N1 = "Err:HOTEND FAN ERROR"; ////c=20
 const char MSG_FANCHECK_PRINT[] PROGMEM_N1 = "Err:PRINT FAN ERROR"; ////c=20
 const char MSG_M112_KILL[] PROGMEM_N1 = "M112 called. Emergency Stop."; ////c=20

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -237,6 +237,7 @@ extern const char MSG_OCTOPRINT_CANCEL[];
 extern const char MSG_OCTOPRINT_READY[];
 extern const char MSG_OCTOPRINT_NOT_READY[];
 extern const char MSG_OCTOPRINT_START[];
+extern const char MSG_OCTOPRINT_UVLO_RECOVERY_READY[];
 extern const char MSG_FANCHECK_HOTEND[];
 extern const char MSG_FANCHECK_PRINT[];
 extern const char MSG_M112_KILL[];

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -41,10 +41,7 @@ void uvlo_() {
     unsigned long time_start = _millis();
 
     // True if a print is already saved to RAM
-    bool sd_print_saved_in_ram = saved_printing && (saved_printing_type == PowerPanic::PRINT_TYPE_SD);
-
-    // Flag to decide whether or not to set EEPROM_UVLO bit
-    bool sd_print = card.sdprinting || sd_print_saved_in_ram;
+    const bool sd_print_saved_in_ram = saved_printing && (saved_printing_type == PowerPanic::PRINT_TYPE_SD);
     const bool pos_invalid = mesh_bed_leveling_flag || homing_flag;
 
     // Conserve as much power as soon as possible
@@ -195,10 +192,7 @@ void uvlo_() {
 #endif
 
     // Finally store the "power outage" flag.
-    // Note: Recovering a print from EEPROM currently assumes the user
-    // is printing from an SD card, this is why this EEPROM byte is only set
-    // when SD card print is detected
-    if(sd_print) eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::PENDING_RECOVERY);
+    eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::PENDING_RECOVERY);
 
     // Increment power failure counter
     eeprom_increment_byte((uint8_t*)EEPROM_POWER_COUNT);

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -316,8 +316,6 @@ ISR(INT4_vect) {
 }
 
 void recover_print(uint8_t automatic) {
-    lcd_update_enable(true);
-    lcd_update(2);
     lcd_setstatuspgm(_i("Recovering print"));////MSG_RECOVERING_PRINT c=20
 
     // Recover position, temperatures and extrude_multipliers

--- a/Firmware/printer_state.h
+++ b/Firmware/printer_state.h
@@ -23,7 +23,6 @@ enum class PrinterState : uint8_t
     HostPrintingFinished = 4,
     IsSDPrinting = 5,
     IsHostPrinting = 6,
-    PowerPanicWaitingForHost = 7,
 };
 
 PrinterState GetPrinterState();

--- a/Firmware/printer_state.h
+++ b/Firmware/printer_state.h
@@ -23,6 +23,7 @@ enum class PrinterState : uint8_t
     HostPrintingFinished = 4,
     IsSDPrinting = 5,
     IsHostPrinting = 6,
+    PowerPanicWaitingForHost = 7,
 };
 
 PrinterState GetPrinterState();


### PR DESCRIPTION
- `M79` sends always `// action:uvlo_recovery_ready` is the ULVO state is 1
- The ULVO state is reset
  - for SD when SD recovery is done
  - for USB when the USB host sends first `G` code command


Sorry this PR is rebased on MK3 branch