### PR TITLE
Set Yes as default on LCD Crash Resume message

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -449,8 +449,8 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex);
 
 void M600_load_filament();
 void M600_load_filament_movements();
-void M600_wait_for_user(float HotendTempBckp);
-void M600_check_state(float nozzle_temp);
+void M600_wait_for_user();
+void M600_check_state();
 void load_filament_final_feed();
 void marlin_wait_for_click();
 float raise_z(float delta);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -617,7 +617,7 @@ void crashdet_detected(uint8_t mask)
         // ask whether to resume printing
         lcd_puts_at_P(0, 1, _T(MSG_RESUME_PRINT));
         lcd_putc('?');
-        uint8_t yesno = lcd_show_yes_no_and_wait(false);
+        uint8_t yesno = lcd_show_yes_no_and_wait(false, LCD_LEFT_BUTTON_CHOICE);
 		if (yesno == LCD_LEFT_BUTTON_CHOICE)
 		{
 			enquecommand_P(PSTR("CRASH_RECOVER"));

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -1039,4 +1039,17 @@ bool CardReader::ToshibaFlashAir_GetIP(uint8_t *ip)
     return card.readExtMemory(1, 1, 0x400+0x150, 4, ip);
 }
 
+//Used for Reprint action
+bool CardReader::FileExists(const char* filename)
+{
+  bool exists = false;
+
+    if (file.open(curDir, filename, O_READ))
+    {
+      exists = true;
+      file.close();
+    }
+    return exists;
+}
+
 #endif //SDSUPPORT

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -83,7 +83,7 @@ public:
   bool ToshibaFlashAir_isEnabled() const { return card.getFlashAirCompatible(); }
   void ToshibaFlashAir_enable(bool enable) { card.setFlashAirCompatible(enable); }
   bool ToshibaFlashAir_GetIP(uint8_t *ip);
-  
+
   //Reprint
   bool FileExists(const char* filename);
 

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -83,6 +83,9 @@ public:
   bool ToshibaFlashAir_isEnabled() const { return card.getFlashAirCompatible(); }
   void ToshibaFlashAir_enable(bool enable) { card.setFlashAirCompatible(enable); }
   bool ToshibaFlashAir_GetIP(uint8_t *ip);
+  
+  //Reprint
+  bool FileExists(const char* filename);
 
 public:
   bool saving;

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -657,6 +657,7 @@ void get_command()
           // queue is complete, but before we process EOF commands prevent
           // re-entry by disabling SD processing from any st_synchronize call
           card.closefile();
+          enableReprint=true;
 
           SERIAL_PROTOCOLLNRPGM(_n("Done printing file"));////MSG_FILE_PRINTED
           char time[30];

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -63,7 +63,6 @@ bool cmdqueue_pop_front()
                 // No serial communication is pending. Reset both pointers to zero.
                 bufindw = 0;
             bufindr = bufindw;
-            enableReprint = true;
         } else {
             // There is at least one ready line in the buffer.
             // First skip the current command ID and iterate up to the end of the string.

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -63,6 +63,7 @@ bool cmdqueue_pop_front()
                 // No serial communication is pending. Reset both pointers to zero.
                 bufindw = 0;
             bufindr = bufindw;
+            enableReprint = true;
         } else {
             // There is at least one ready line in the buffer.
             // First skip the current command ID and iterate up to the end of the string.
@@ -657,7 +658,6 @@ void get_command()
           // queue is complete, but before we process EOF commands prevent
           // re-entry by disabling SD processing from any st_synchronize call
           card.closefile();
-          enableReprint=true;
 
           SERIAL_PROTOCOLLNRPGM(_n("Done printing file"));////MSG_FILE_PRINTED
           char time[30];

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -190,7 +190,7 @@ extern const char MSG_LOAD_ALL[] PROGMEM_I1 = ISTR("Load All"); ////MSG_LOAD_ALL
 extern const char MSG_NOZZLE_CNG_MENU [] PROGMEM_I1 = ISTR("Nozzle change");////MSG_NOZZLE_CNG_MENU c=18
 extern const char MSG_NOZZLE_CNG_READ_HELP [] PROGMEM_I1 = ISTR("For a Nozzle change please read\nprusa.io/nozzle-mk3s");////MSG_NOZZLE_CNG_READ_HELP c=20 r=4
 extern const char MSG_NOZZLE_CNG_CHANGED [] PROGMEM_I1 = ISTR("Hotend at 280C! Nozzle changed and tightened to specs?");////MSG_NOZZLE_CNG_CHANGED c=20 r=6
-
+extern const char MSG_REPRINT [] PROGMEM_I1 = ISTR("Reprint"); ////MSG_REPRINT c=7
 //not internationalized messages
 #if 0
 const char MSG_FW_VERSION_BETA[] PROGMEM_N1 = "You are using a BETA firmware version! It is in a development state! Use this version with CAUTION as it may DAMAGE the printer!"; ////MSG_FW_VERSION_BETA c=20 r=8

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -232,6 +232,7 @@ const char MSG_OCTOPRINT_RESUMED[] PROGMEM_N1 = "// action:resumed"; ////
 const char MSG_OCTOPRINT_CANCEL[] PROGMEM_N1 = "// action:cancel"; ////
 const char MSG_OCTOPRINT_READY[] PROGMEM_N1 = "// action:ready"; ////
 const char MSG_OCTOPRINT_NOT_READY[] PROGMEM_N1 = "// action:not_ready"; ////
+const char MSG_OCTOPRINT_REPRINT[] PROGMEM_N1 = "// action:reprint"; ////
 const char MSG_FANCHECK_HOTEND[] PROGMEM_N1 = "Err:HOTEND FAN ERROR"; ////c=20
 const char MSG_FANCHECK_PRINT[] PROGMEM_N1 = "Err:PRINT FAN ERROR"; ////c=20
 const char MSG_M112_KILL[] PROGMEM_N1 = "M112 called. Emergency Stop."; ////c=20

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -190,7 +190,7 @@ extern const char MSG_LOAD_ALL[] PROGMEM_I1 = ISTR("Load All"); ////MSG_LOAD_ALL
 extern const char MSG_NOZZLE_CNG_MENU [] PROGMEM_I1 = ISTR("Nozzle change");////MSG_NOZZLE_CNG_MENU c=18
 extern const char MSG_NOZZLE_CNG_READ_HELP [] PROGMEM_I1 = ISTR("For a Nozzle change please read\nprusa.io/nozzle-mk3s");////MSG_NOZZLE_CNG_READ_HELP c=20 r=4
 extern const char MSG_NOZZLE_CNG_CHANGED [] PROGMEM_I1 = ISTR("Hotend at 280C! Nozzle changed and tightened to specs?");////MSG_NOZZLE_CNG_CHANGED c=20 r=6
-extern const char MSG_REPRINT [] PROGMEM_I1 = ISTR("Reprint"); ////MSG_REPRINT c=7
+extern const char MSG_REPRINT [] PROGMEM_I1 = ISTR("Reprint"); ////MSG_REPRINT c=18
 //not internationalized messages
 #if 0
 const char MSG_FW_VERSION_BETA[] PROGMEM_N1 = "You are using a BETA firmware version! It is in a development state! Use this version with CAUTION as it may DAMAGE the printer!"; ////MSG_FW_VERSION_BETA c=20 r=8

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -191,6 +191,7 @@ extern const char MSG_LOAD_ALL[];
 extern const char MSG_NOZZLE_CNG_MENU [];
 extern const char MSG_NOZZLE_CNG_READ_HELP [];
 extern const char MSG_NOZZLE_CNG_CHANGED [];
+extern const char MSG_REPRINT [];
 
 //not internationalized messages
 #if 0

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -236,6 +236,7 @@ extern const char MSG_OCTOPRINT_RESUMED[];
 extern const char MSG_OCTOPRINT_CANCEL[];
 extern const char MSG_OCTOPRINT_READY[];
 extern const char MSG_OCTOPRINT_NOT_READY[];
+extern const char MSG_OCTOPRINT_REPRINT[];
 extern const char MSG_FANCHECK_HOTEND[];
 extern const char MSG_FANCHECK_PRINT[];
 extern const char MSG_M112_KILL[];

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -340,6 +340,8 @@ private:
     void UnloadInner();
     void CutFilamentInner(uint8_t slot);
 
+    void SetCurrentTool(uint8_t ex);
+
     ProtocolLogic logic;          ///< implementation of the protocol logic layer
     uint8_t extruder;             ///< currently active slot in the MMU ... somewhat... not sure where to get it from yet
     uint8_t tool_change_extruder; ///< only used for UI purposes

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -412,7 +412,7 @@ struct TuneItem {
 
 static const TuneItem TuneItems[] PROGMEM = {
   { (uint8_t)Register::Selector_sg_thrs_R, 1, 4},
-  { (uint8_t)Register::Idler_sg_thrs_R, 4, 7},
+  { (uint8_t)Register::Idler_sg_thrs_R, 2, 10},
 };
 
 static_assert(sizeof(TuneItems)/sizeof(TuneItem) == 2);

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2676,7 +2676,7 @@ static bool autotune(int16_t cal_temp)
         set_fan_speed(speed);
         wait(10000);
 
-        sprintf_P(tm_message, PSTR("TM: R[%u] estimat."), (unsigned)i);
+        sprintf_P(tm_message, PSTR("TM: R[%u] estimate."), (unsigned)i);
         lcd_setstatus_serial(tm_message);
         samples = record();
         if(temp_error_state.v || !samples)

--- a/Firmware/tone04.c
+++ b/Firmware/tone04.c
@@ -14,24 +14,24 @@
 void timer4_init(void)
 {
 	CRITICAL_SECTION_START;
-	
+
 	SET_OUTPUT(BEEPER);
 	WRITE(BEEPER, LOW);
-	
+
 	SET_OUTPUT(EXTRUDER_0_AUTO_FAN_PIN);
-	
+
 	// Set timer mode 9 (PWM,Phase and Frequency Correct)
 	// Prescaler is CLK/1024
 	// Output compare is disabled on all timer pins
 	// Input capture is disabled
 	// All interrupts are disabled
-	TCCR4A = (1 << WGM40);
-	TCCR4B = (1 << WGM43) | (1 << CS42) | (1 << CS40);
-	OCR4A = 255;
-	OCR4B = 255;
-	OCR4C = 255;
+	TCCR4A = _BV(WGM40);
+	TCCR4B = _BV(WGM43) | _BV(CS42) | _BV(CS40);
+	OCR4A = 255U;
+	OCR4B = 255U;
+	OCR4C = 255U;
 	TIMSK4 = 0;
-	
+
 	CRITICAL_SECTION_END;
 }
 
@@ -41,7 +41,7 @@ void timer4_set_fan0(uint8_t duty)
 	if (duty == 0 || duty == 255)
 	{
 		// We use digital logic if the duty cycle is 0% or 100%
-		TCCR4A &= ~(1 << COM4C1);
+		TCCR4A &= ~_BV(COM4C1);
 		OCR4C = 0;
 		WRITE(EXTRUDER_0_AUTO_FAN_PIN, duty);
 	}
@@ -52,8 +52,8 @@ void timer4_set_fan0(uint8_t duty)
 		// Better be safe than sorry.
 		CRITICAL_SECTION_START;
 		// Enable the PWM output on the fan pin.
-		TCCR4A |= (1 << COM4C1);
-		OCR4C = (((uint32_t)duty) * ((uint32_t)((TIMSK4 & (1 << OCIE4A))?OCR4A:255))) / ((uint32_t)255);
+		TCCR4A |= _BV(COM4C1);
+		OCR4C = (((uint16_t)duty) * ((uint16_t)((TIMSK4 & _BV(OCIE4A)) ? OCR4A : 255U))) / 255U;
 		CRITICAL_SECTION_END;
 	}
 }
@@ -75,25 +75,26 @@ void tone4(_UNUSED uint8_t _pin, uint16_t frequency)
 {
 	//this ocr and prescalarbits calculation is taken from the Arduino core and simplified for one type of timer only
 	uint8_t prescalarbits = 0b001;
-	uint32_t ocr = F_CPU / frequency / 2 - 1;
-	
-	if (ocr > 0xffff)
-	{
-		ocr = F_CPU / frequency / 2 / 64 - 1;
+	uint32_t pwm_freq = F_CPU / (2 * frequency);
+
+	if (pwm_freq > UINT16_MAX) {
+		pwm_freq /= 64; // Increase prescaler to 64
 		prescalarbits = 0b011;
 	}
-	
+
+	uint16_t ocr = pwm_freq - 1;
+
 	CRITICAL_SECTION_START;
 	// Set calcualted prescaler
 	TCCR4B = (TCCR4B & 0b11111000) | prescalarbits;
 #ifdef EXTRUDER_0_AUTO_FAN_PIN
 	// Scale the fan PWM duty cycle so that it remains constant, but at the tone frequency
-	OCR4C = (((uint32_t)OCR4C) * ocr) / (uint32_t)((TIMSK4 & (1 << OCIE4A))?OCR4A:255);
+	OCR4C = (OCR4C * ocr) / (uint16_t)((TIMSK4 & _BV(OCIE4A)) ? OCR4A : 255U);
 #endif //EXTRUDER_0_AUTO_FAN_PIN
 	// Set calcualted ocr
 	OCR4A = ocr;
 	// Enable Output compare A interrupt and timer overflow interrupt
-	TIMSK4 |= (1 << OCIE4A) | (1 << TOIE4);
+	TIMSK4 |= _BV(OCIE4A) | _BV(TOIE4);
 	CRITICAL_SECTION_END;
 }
 
@@ -101,14 +102,14 @@ void noTone4(_UNUSED uint8_t _pin)
 {
 	CRITICAL_SECTION_START;
 	// Revert prescaler to CLK/1024
-	TCCR4B = (TCCR4B & 0b11111000) | (1 << CS42) | (1 << CS40);
+	TCCR4B = (TCCR4B & 0b11111000) | _BV(CS42) | _BV(CS40);
 #ifdef EXTRUDER_0_AUTO_FAN_PIN
 	// Scale the fan OCR back to the original value.
-	OCR4C = (((uint32_t)OCR4C) * (uint32_t)255) / (uint32_t)((TIMSK4 & (1 << OCIE4A))?OCR4A:255);
+	OCR4C = (OCR4C * 255U) / (uint16_t)((TIMSK4 & _BV(OCIE4A)) ? OCR4A : 255U);
 #endif //EXTRUDER_0_AUTO_FAN_PIN
-	OCR4A = 255;
+	OCR4A = 255U;
 	// Disable Output compare A interrupt and timer overflow interrupt
-	TIMSK4 &= ~((1 << OCIE4A) | (1 << TOIE4));
+	TIMSK4 &= ~(_BV(OCIE4A) | _BV(TOIE4));
 	CRITICAL_SECTION_END;
 	// Turn beeper off if it was on when noTone was called
 	WRITE(BEEPER, 0);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7473,8 +7473,6 @@ void reprint_from_eeprom() {
 
 	enableReprint=false;
 
-	//cmdqueue_reset();
-
 	depth = eeprom_read_byte((uint8_t*)EEPROM_DIR_DEPTH);
 
 	MYSERIAL.println(int(depth));
@@ -7483,8 +7481,6 @@ void reprint_from_eeprom() {
 			dir_name[j] = eeprom_read_byte((uint8_t*)EEPROM_DIRS + j + 8 * i);
 		}
 		dir_name[8] = '\0';
-		MYSERIAL.println(dir_name);
-		// strcpy(dir_names[i], dir_name);
 		card.chdir(dir_name, false);
 	}
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7475,7 +7475,6 @@ void reprint_from_eeprom() {
 
 	depth = eeprom_read_byte((uint8_t*)EEPROM_DIR_DEPTH);
 
-	MYSERIAL.println(int(depth));
 	for (int i = 0; i < depth; i++) {
 		for (int j = 0; j < 8; j++) {
 			dir_name[j] = eeprom_read_byte((uint8_t*)EEPROM_DIRS + j + 8 * i);
@@ -7501,9 +7500,7 @@ void reprint_from_eeprom() {
 			strcat_P(altfilename, PSTR(".g"));
 		}
 	}
-	MYSERIAL.print(altfilename);
-
-    // M23: Select SD file
+	// M23: Select SD file
     enquecommandf_P(MSG_M23, altfilename);
     // M24: Start/resume SD print
     enquecommand_P(MSG_M24);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -255,6 +255,8 @@ uint8_t selected_sheet = 0;
 bool bMain;                                       // flag (i.e. 'fake parameter') for 'lcd_sdcard_menu()' function
 bool bSettings;                                   // flag (i.e. 'fake parameter') for 'lcd_hw_setup_menu()' function
 
+//action: Reprint
+bool enableReprint = false;
 static void lcd_implementation_drawmenu_sdfile(uint8_t row, const char* longFilename)
 {
     uint8_t len = LCD_WIDTH - 1;
@@ -5193,6 +5195,14 @@ static void lcd_main_menu()
     MENU_ITEM_FUNCTION_P(PSTR("power panic"), uvlo_);
 #endif //TMC2130_DEBUG
 
+    // Menu item for reprint
+    if(!printer_active() && enableReprint && card.cardOK)
+    {
+        MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), reprint_from_eeprom);
+    }else if (!card.cardOK)
+    {
+        enableReprint = false;
+    }
     // Menu is never shown when idle
     if (babystep_allowed_strict() && (printJobOngoing() || lcd_commands_type == LcdCommands::Layer1Cal))
         MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), lcd_babystep_z);//8
@@ -7453,4 +7463,53 @@ void lcd_heat_bed_on_load_toggle()
     else
         value = !value;
     eeprom_update_byte((uint8_t*)EEPROM_HEAT_BED_ON_LOAD_FILAMENT, value);
+}
+
+void reprint_from_eeprom() {
+	char cmd[30];
+	char filename[13];
+	char altfilename[13];
+	uint8_t depth = 0;
+	char dir_name[9];
+
+	enableReprint=false;
+
+	//cmdqueue_reset();
+
+	depth = eeprom_read_byte((uint8_t*)EEPROM_DIR_DEPTH);
+
+	MYSERIAL.println(int(depth));
+	for (int i = 0; i < depth; i++) {
+		for (int j = 0; j < 8; j++) {
+			dir_name[j] = eeprom_read_byte((uint8_t*)EEPROM_DIRS + j + 8 * i);
+		}
+		dir_name[8] = '\0';
+		MYSERIAL.println(dir_name);
+		// strcpy(dir_names[i], dir_name);
+		card.chdir(dir_name, false);
+	}
+
+	for (int i = 0; i < 8; i++) {
+		filename[i] = eeprom_read_byte((uint8_t*)EEPROM_FILENAME + i);
+	}
+	filename[8] = '\0';
+
+	strcpy(altfilename,filename);
+	if (!card.FileExists(altfilename))
+	{
+		strcat_P(filename, PSTR(".gco"));
+		if (card.FileExists(filename))
+		{
+			strcpy(altfilename,filename);
+		}else
+		{
+			strcat_P(altfilename, PSTR(".g"));
+		}
+	}
+	MYSERIAL.print(altfilename);
+	sprintf_P(cmd, PSTR("M23 %s"), altfilename);
+	enquecommand(cmd);
+  	sprintf_P(cmd, PSTR("M24"));
+	enquecommand(cmd);
+	lcd_return_to_status();
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -45,7 +45,6 @@
 
 #include "Prusa_farm.h"
 
-#include "power_panic.h"
 
 static void lcd_sd_updir();
 static void lcd_mesh_bed_leveling_settings();
@@ -259,6 +258,8 @@ bool bSettings;                                   // flag (i.e. 'fake parameter'
 
 //action: Reprint
 bool enableReprint = false;
+bool enableReprintUSB = false;
+
 static void lcd_implementation_drawmenu_sdfile(uint8_t row, const char* longFilename)
 {
     uint8_t len = LCD_WIDTH - 1;
@@ -5198,13 +5199,13 @@ static void lcd_main_menu()
 #endif //TMC2130_DEBUG
 
     // Menu item for reprint
-    if(!printer_active() && enableReprint && card.cardOK)
+    if(!printer_active() && enableReprint && card.cardOK && !enableReprintUSB)
     {
         MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), reprint_from_eeprom);
-    }else if(!printer_active() && enableReprint && saved_printing_type == PowerPanic::PRINT_TYPE_USB)
+    }else if(!printer_active() && enableReprintUSB )
     {
-        lcd_reprint_usb_print();
-    }else if (!card.cardOK && (saved_printing_type != PowerPanic::PRINT_TYPE_USB))
+        MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), lcd_reprint_usb_print);
+    }else if (!card.cardOK)
     {
         enableReprint = false;
     }
@@ -7516,4 +7517,7 @@ void reprint_from_eeprom() {
 void lcd_reprint_usb_print()
 {
     SERIAL_PROTOCOLLNRPGM(MSG_OCTOPRINT_REPRINT);
+    enableReprint=false;
+    enableReprintUSB=false;
+    lcd_return_to_status();
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5201,10 +5201,10 @@ static void lcd_main_menu()
     if(!printer_active() && enableReprint && card.cardOK)
     {
         MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), reprint_from_eeprom);
-    }else if(saved_printing_type == PowerPanic::PRINT_TYPE_USB) 
+    }else if(!printer_active() && enableReprint && saved_printing_type == PowerPanic::PRINT_TYPE_USB) 
     {
         lcd_reprint_usb_print();
-    }else if (!card.cardOK)
+    }else if (!card.cardOK && (saved_printing_type != PowerPanic::PRINT_TYPE_USB))
     {
         enableReprint = false;
     }
@@ -7505,13 +7505,10 @@ void reprint_from_eeprom() {
 			strcat_P(altfilename, PSTR(".g"));
 		}
 	}
-    if (lcd_show_fullscreen_message_yes_no_and_wait_P(altfilename, false, LCD_LEFT_BUTTON_CHOICE)==LCD_LEFT_BUTTON_CHOICE)
-    {
-	    // M23: Select SD file
-        enquecommandf_P(MSG_M23, altfilename);
-        // M24: Start/resume SD print
-        enquecommand_P(MSG_M24);
-    }
+    // M23: Select SD file
+    enquecommandf_P(MSG_M23, altfilename);
+    // M24: Start/resume SD print
+    enquecommand_P(MSG_M24);
     lcd_return_to_status();
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -45,6 +45,8 @@
 
 #include "Prusa_farm.h"
 
+#include "power_panic.h"
+
 static void lcd_sd_updir();
 static void lcd_mesh_bed_leveling_settings();
 #ifdef LCD_BL_PIN
@@ -5199,6 +5201,9 @@ static void lcd_main_menu()
     if(!printer_active() && enableReprint && card.cardOK)
     {
         MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), reprint_from_eeprom);
+    }else if(saved_printing_type == PowerPanic::PRINT_TYPE_USB) 
+    {
+        lcd_reprint_usb_print();
     }else if (!card.cardOK)
     {
         enableReprint = false;
@@ -7500,9 +7505,18 @@ void reprint_from_eeprom() {
 			strcat_P(altfilename, PSTR(".g"));
 		}
 	}
-	// M23: Select SD file
-    enquecommandf_P(MSG_M23, altfilename);
-    // M24: Start/resume SD print
-    enquecommand_P(MSG_M24);
-	lcd_return_to_status();
+    if (lcd_show_fullscreen_message_yes_no_and_wait_P(altfilename, false, LCD_LEFT_BUTTON_CHOICE)==LCD_LEFT_BUTTON_CHOICE)
+    {
+	    // M23: Select SD file
+        enquecommandf_P(MSG_M23, altfilename);
+        // M24: Start/resume SD print
+        enquecommand_P(MSG_M24);
+    }
+    lcd_return_to_status();
+}
+
+//! @brief Send host action "reprint"
+void lcd_reprint_usb_print()
+{
+    SERIAL_PROTOCOLLNRPGM(MSG_OCTOPRINT_REPRINT);
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7466,7 +7466,6 @@ void lcd_heat_bed_on_load_toggle()
 }
 
 void reprint_from_eeprom() {
-	char cmd[30];
 	char filename[13];
 	char altfilename[13];
 	uint8_t depth = 0;
@@ -7507,9 +7506,10 @@ void reprint_from_eeprom() {
 		}
 	}
 	MYSERIAL.print(altfilename);
-	sprintf_P(cmd, PSTR("M23 %s"), altfilename);
-	enquecommand(cmd);
-  	sprintf_P(cmd, PSTR("M24"));
-	enquecommand(cmd);
+
+    // M23: Select SD file
+    enquecommandf_P(MSG_M23, altfilename);
+    // M24: Start/resume SD print
+    enquecommand_P(MSG_M24);
 	lcd_return_to_status();
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5201,7 +5201,7 @@ static void lcd_main_menu()
     if(!printer_active() && enableReprint && card.cardOK)
     {
         MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), reprint_from_eeprom);
-    }else if(!printer_active() && enableReprint && saved_printing_type == PowerPanic::PRINT_TYPE_USB) 
+    }else if(!printer_active() && enableReprint && saved_printing_type == PowerPanic::PRINT_TYPE_USB)
     {
         lcd_reprint_usb_print();
     }else if (!card.cardOK && (saved_printing_type != PowerPanic::PRINT_TYPE_USB))

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5199,15 +5199,16 @@ static void lcd_main_menu()
 #endif //TMC2130_DEBUG
 
     // Menu item for reprint
-    if(!printer_active() && enableReprint && card.cardOK && !enableReprintUSB)
+    if(!printer_active() && enableReprint && card.cardOK && !enableReprintUSB && (heating_status == HeatingStatus::NO_HEATING))
     {
         MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), reprint_from_eeprom);
-    }else if(!printer_active() && enableReprintUSB )
+    }else if(!printer_active() && enableReprintUSB && (heating_status == HeatingStatus::NO_HEATING))
     {
         MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), lcd_reprint_usb_print);
     }else if (!card.cardOK)
     {
         enableReprint = false;
+        enableReprintUSB = false;
     }
     // Menu is never shown when idle
     if (babystep_allowed_strict() && (printJobOngoing() || lcd_commands_type == LcdCommands::Layer1Cal))

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -19,6 +19,10 @@ void ultralcd_init();
 #define LCD_STATUS_INFO_TIMEOUT 20000
 #define LCD_STATUS_DELAYED_TIMEOUT 4000
 
+// Reprint
+void reprint_from_eeprom();
+extern bool enableReprint;
+
 // Set the current status message (equivalent to LCD_STATUS_NONE)
 void lcdui_print_status_line(void);
 void lcd_clearstatus();

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -58,6 +58,7 @@ void lcd_loading_color();
 void lcd_sdcard_stop();
 void lcd_pause_print();
 void lcd_pause_usb_print();
+void lcd_reprint_usb_print();
 void lcd_resume_print();
 void lcd_print_stop(); // interactive print stop
 void print_stop(bool interactive=false);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -21,7 +21,6 @@ void ultralcd_init();
 
 // Reprint
 void reprint_from_eeprom();
-extern bool enableReprint;
 
 // Set the current status message (equivalent to LCD_STATUS_NONE)
 void lcdui_print_status_line(void);

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr ""

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -2470,3 +2470,7 @@ msgstr ""
 #. MSG_FW_MK3_DETECTED c=20 r=4
 msgid "MK3 firmware detected on MK3S printer"
 msgstr ""
+
+#. MSG_REPRINT c=7 
+msgid "Reprint"
+msgstr ""

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -8,91 +8,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr ""
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr ""
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr ""
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ""
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr ""
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr ""
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr ""
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr ""
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr ""
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr ""
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr ""
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr ""
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr ""
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr ""
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr ""
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -104,274 +103,274 @@ msgid "Avoiding grind"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr ""
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr ""
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr ""
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr ""
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr ""
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr ""
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
 msgstr ""
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr ""
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr ""
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr ""
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr ""
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr ""
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr ""
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr ""
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr ""
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr ""
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr ""
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr ""
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr ""
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr ""
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr ""
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr ""
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr ""
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr ""
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr ""
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr ""
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr ""
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr ""
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr ""
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr ""
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr ""
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr ""
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr ""
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr ""
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr ""
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr ""
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -379,34 +378,34 @@ msgid ""
 msgstr ""
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr ""
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr ""
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr ""
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr ""
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr ""
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr ""
 
@@ -418,8 +417,8 @@ msgid "Disengaging idler"
 msgstr ""
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -427,20 +426,20 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr ""
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr ""
 
@@ -469,18 +468,18 @@ msgid "ERR Wait for User"
 msgstr ""
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr ""
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr ""
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr ""
 
@@ -492,17 +491,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr ""
 
@@ -514,127 +513,127 @@ msgid "Engaging idler"
 msgstr ""
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr ""
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr ""
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr ""
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr ""
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr ""
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr ""
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr ""
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr ""
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr ""
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr ""
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
 msgstr ""
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
 msgstr ""
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr ""
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr ""
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr ""
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr ""
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr ""
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr ""
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr ""
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr ""
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr ""
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr ""
 
@@ -663,196 +662,196 @@ msgid "Feeding to nozzle"
 msgstr ""
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr ""
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr ""
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr ""
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
 msgstr ""
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr ""
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr ""
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr ""
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
 msgstr ""
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
 msgstr ""
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
 msgstr ""
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr ""
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr ""
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr ""
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr ""
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
 msgstr ""
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr ""
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
 msgstr ""
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr ""
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
 msgstr ""
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr ""
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
 msgstr ""
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr ""
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr ""
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr ""
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr ""
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr ""
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -860,15 +859,15 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
 msgstr ""
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr ""
 
@@ -879,404 +878,402 @@ msgid "Homing"
 msgstr ""
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr ""
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr ""
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr ""
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr ""
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr ""
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr ""
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr ""
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
 msgstr ""
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr ""
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr ""
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr ""
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr ""
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr ""
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr ""
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr ""
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr ""
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr ""
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr ""
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr ""
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr ""
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr ""
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr ""
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr ""
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr ""
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr ""
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr ""
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr ""
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr ""
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr ""
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr ""
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr ""
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
 msgstr ""
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr ""
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr ""
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr ""
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr ""
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr ""
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr ""
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr ""
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr ""
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr ""
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr ""
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr ""
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr ""
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr ""
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr ""
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr ""
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr ""
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr ""
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr ""
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr ""
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr ""
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr ""
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr ""
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr ""
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr ""
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr ""
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr ""
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr ""
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr ""
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr ""
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr ""
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr ""
 
@@ -1287,105 +1284,104 @@ msgid "Moving selector"
 msgstr ""
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr ""
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr ""
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr ""
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr ""
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr ""
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr ""
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr ""
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr ""
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr ""
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr ""
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1398,87 +1394,87 @@ msgid "OK"
 msgstr ""
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr ""
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr ""
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr ""
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr ""
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr ""
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr ""
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr ""
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr ""
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr ""
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr ""
 
@@ -1489,13 +1485,13 @@ msgid "Parking selector"
 msgstr ""
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr ""
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr ""
 
@@ -1506,156 +1502,156 @@ msgid "Performing cut"
 msgstr ""
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
 msgstr ""
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
 msgstr ""
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr ""
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr ""
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
 msgstr ""
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr ""
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr ""
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr ""
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr ""
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr ""
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr ""
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr ""
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr ""
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr ""
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr ""
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr ""
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr ""
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr ""
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr ""
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr ""
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr ""
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr ""
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr ""
 
@@ -1666,55 +1662,55 @@ msgid "Preparing blade"
 msgstr ""
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr ""
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr ""
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr ""
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr ""
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr ""
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr ""
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr ""
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
 msgstr ""
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 
@@ -1725,32 +1721,32 @@ msgid "Pushing filament"
 msgstr ""
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr ""
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr ""
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr ""
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr ""
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr ""
 
@@ -1760,36 +1756,36 @@ msgid "Reprint"
 msgstr ""
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
 msgstr ""
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr ""
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr ""
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr ""
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr ""
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr ""
 
@@ -1800,7 +1796,7 @@ msgid "Retract from FINDA"
 msgstr ""
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr ""
 
@@ -1811,81 +1807,81 @@ msgid "Returning selector"
 msgstr ""
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
 msgstr ""
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr ""
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr ""
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr ""
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr ""
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr ""
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr ""
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr ""
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr ""
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr ""
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr ""
 
@@ -1896,55 +1892,55 @@ msgid "Selecting fil. slot"
 msgstr ""
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
 msgstr ""
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr ""
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr ""
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr ""
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr ""
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr ""
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr ""
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr ""
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1959,31 +1955,31 @@ msgid "Set not Ready"
 msgstr ""
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr ""
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr ""
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr ""
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr ""
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1992,175 +1988,175 @@ msgid ""
 msgstr ""
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr ""
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr ""
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr ""
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
 msgstr ""
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr ""
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr ""
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr ""
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr ""
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr ""
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr ""
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr ""
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr ""
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr ""
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr ""
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr ""
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr ""
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr ""
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr ""
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr ""
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr ""
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr ""
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr ""
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr ""
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr ""
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr ""
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr ""
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2168,92 +2164,92 @@ msgid ""
 msgstr ""
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
 msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr ""
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr ""
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr ""
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr ""
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr ""
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr ""
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr ""
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr ""
 
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr ""
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr ""
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr ""
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr ""
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr ""
 
@@ -2270,23 +2266,23 @@ msgid "Unloading to pulley"
 msgstr ""
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr ""
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr ""
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2295,173 +2291,187 @@ msgid ""
 msgstr ""
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr ""
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr ""
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr ""
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr ""
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr ""
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr ""
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr ""
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr ""
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr ""
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr ""
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr ""
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr ""
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr ""
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr ""
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr ""
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr ""
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr ""
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr ""
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr ""
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr ""
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr ""
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
+msgstr ""
+
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr ""
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr ""
+
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
 msgstr ""

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -8,90 +8,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr ""
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr ""
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr ""
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ""
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr ""
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr ""
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr ""
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr ""
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr ""
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr ""
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr ""
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr ""
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr ""
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr ""
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr ""
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -103,274 +104,274 @@ msgid "Avoiding grind"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr ""
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr ""
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr ""
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr ""
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr ""
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr ""
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
 msgstr ""
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr ""
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr ""
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr ""
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr ""
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr ""
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr ""
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr ""
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr ""
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr ""
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr ""
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr ""
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr ""
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr ""
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr ""
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr ""
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr ""
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr ""
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr ""
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr ""
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr ""
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr ""
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr ""
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr ""
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr ""
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr ""
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr ""
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr ""
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr ""
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr ""
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -378,34 +379,34 @@ msgid ""
 msgstr ""
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr ""
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr ""
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr ""
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr ""
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr ""
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr ""
 
@@ -417,8 +418,8 @@ msgid "Disengaging idler"
 msgstr ""
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -426,20 +427,20 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr ""
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr ""
 
@@ -468,18 +469,18 @@ msgid "ERR Wait for User"
 msgstr ""
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr ""
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr ""
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr ""
 
@@ -491,17 +492,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr ""
 
@@ -513,127 +514,127 @@ msgid "Engaging idler"
 msgstr ""
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr ""
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr ""
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr ""
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr ""
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr ""
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr ""
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr ""
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr ""
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr ""
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr ""
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
 msgstr ""
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
 msgstr ""
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr ""
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr ""
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr ""
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr ""
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr ""
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr ""
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr ""
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr ""
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr ""
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr ""
 
@@ -662,196 +663,196 @@ msgid "Feeding to nozzle"
 msgstr ""
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr ""
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr ""
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr ""
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
 msgstr ""
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr ""
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr ""
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr ""
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
 msgstr ""
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
 msgstr ""
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
 msgstr ""
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr ""
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr ""
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr ""
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr ""
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
 msgstr ""
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr ""
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
 msgstr ""
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr ""
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
 msgstr ""
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr ""
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
 msgstr ""
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr ""
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr ""
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr ""
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr ""
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr ""
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -859,15 +860,15 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
 msgstr ""
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr ""
 
@@ -878,402 +879,404 @@ msgid "Homing"
 msgstr ""
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr ""
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr ""
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr ""
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr ""
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr ""
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr ""
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr ""
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
 msgstr ""
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr ""
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr ""
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr ""
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr ""
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr ""
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr ""
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr ""
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr ""
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr ""
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr ""
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr ""
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr ""
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr ""
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr ""
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr ""
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr ""
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr ""
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr ""
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr ""
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr ""
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr ""
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr ""
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr ""
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
 msgstr ""
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr ""
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr ""
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr ""
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr ""
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr ""
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr ""
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr ""
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr ""
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr ""
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr ""
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr ""
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr ""
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr ""
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr ""
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr ""
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr ""
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr ""
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr ""
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr ""
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr ""
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr ""
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr ""
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr ""
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr ""
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr ""
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr ""
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr ""
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr ""
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr ""
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr ""
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr ""
 
@@ -1284,104 +1287,105 @@ msgid "Moving selector"
 msgstr ""
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr ""
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr ""
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr ""
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr ""
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr ""
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr ""
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr ""
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr ""
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr ""
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr ""
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1394,87 +1398,87 @@ msgid "OK"
 msgstr ""
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr ""
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr ""
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr ""
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr ""
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr ""
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr ""
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr ""
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr ""
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr ""
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr ""
 
@@ -1485,13 +1489,13 @@ msgid "Parking selector"
 msgstr ""
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr ""
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr ""
 
@@ -1502,156 +1506,156 @@ msgid "Performing cut"
 msgstr ""
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
 msgstr ""
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
 msgstr ""
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr ""
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr ""
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
 msgstr ""
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr ""
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr ""
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr ""
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr ""
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr ""
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr ""
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr ""
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr ""
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr ""
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr ""
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr ""
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr ""
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr ""
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr ""
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr ""
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr ""
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr ""
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr ""
 
@@ -1662,55 +1666,55 @@ msgid "Preparing blade"
 msgstr ""
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr ""
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr ""
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr ""
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr ""
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr ""
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr ""
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr ""
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
 msgstr ""
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 
@@ -1721,66 +1725,71 @@ msgid "Pushing filament"
 msgstr ""
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr ""
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr ""
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr ""
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr ""
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr ""
 
+#. MSG_REPRINT c=7
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
+msgid "Reprint"
+msgstr ""
+
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
 msgstr ""
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr ""
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr ""
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr ""
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr ""
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr ""
 
@@ -1791,7 +1800,7 @@ msgid "Retract from FINDA"
 msgstr ""
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr ""
 
@@ -1802,81 +1811,81 @@ msgid "Returning selector"
 msgstr ""
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
 msgstr ""
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr ""
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr ""
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr ""
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr ""
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr ""
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr ""
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr ""
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr ""
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr ""
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr ""
 
@@ -1887,55 +1896,55 @@ msgid "Selecting fil. slot"
 msgstr ""
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
 msgstr ""
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr ""
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr ""
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr ""
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr ""
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr ""
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr ""
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr ""
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1950,31 +1959,31 @@ msgid "Set not Ready"
 msgstr ""
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr ""
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr ""
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr ""
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr ""
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1983,175 +1992,175 @@ msgid ""
 msgstr ""
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr ""
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr ""
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr ""
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
 msgstr ""
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr ""
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr ""
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr ""
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr ""
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr ""
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr ""
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr ""
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr ""
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr ""
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr ""
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr ""
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr ""
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr ""
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr ""
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr ""
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr ""
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr ""
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr ""
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr ""
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr ""
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr ""
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr ""
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2159,92 +2168,92 @@ msgid ""
 msgstr ""
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
 msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr ""
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr ""
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr ""
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr ""
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr ""
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr ""
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr ""
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr ""
 
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr ""
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr ""
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr ""
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr ""
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr ""
 
@@ -2261,23 +2270,23 @@ msgid "Unloading to pulley"
 msgstr ""
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr ""
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr ""
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2286,191 +2295,173 @@ msgid ""
 msgstr ""
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr ""
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr ""
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr ""
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr ""
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr ""
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr ""
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr ""
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr ""
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr ""
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr ""
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr ""
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr ""
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr ""
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr ""
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr ""
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr ""
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr ""
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr ""
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr ""
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr ""
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr ""
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
-msgstr ""
-
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr ""
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr ""
-
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr ""
-
-#. MSG_REPRINT c=7 
-msgid "Reprint"
 msgstr ""

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2565,6 +2565,11 @@ msgstr "Připravit"
 msgid "Set not Ready"
 msgstr "Zrušit Připravena"
 
+#. MSG_REPRINT c=7
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Reprint"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."
 

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 nebo starší"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 nebo novější"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "%s očekávaná verze"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Zrušit"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Doladění Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Vše OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Vše je hotovo. Tisku zdar!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Vždy"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Okolí"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "Dojely oba Z vozíky k-hornímu dorazu?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Automat."
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "AutoZavedení fil."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -115,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Eliminace obroušení"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Osa"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Délka osy"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Zpět"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Podložka"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Zahřívání bedu"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Bed OK."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Korekce podložky"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -168,54 +167,54 @@ msgstr ""
 "Kalibrace Z selhala. Sensor nesepnul. Znečištená tryska? Čekám na reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Podložka/Topení"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Stav řemenu"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Test řemenu"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Detekován výpadek proudu. Obnovit tisk?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Jasný"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Podsvícení"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "CHYBA KOMUNIKACE"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Kalibrace XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Kalibrovat Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -224,13 +223,13 @@ msgstr ""
 " tlačítkem."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Kalibruji Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -239,155 +238,155 @@ msgstr ""
 "tlacitkem."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Kalibruji výchozí p."
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Kalibrace"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Kalibrace OK"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Chyba pohybu selektoru nebo idleru"
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr "Nelze provést akci, filament je zaveden. Nejprve jej vyjměte."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "Karta vyjmuta"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Vyměňte SD kartu"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Vyměnit filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Změna úspěšná!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Výměna ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Kontrola osy X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Kontrola osy Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Kontrola osy Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Kontrola podložky"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Kontrola endstopů"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Kontroluji soubor"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Kontrola hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Kontrola senzorů"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Kontrola"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "Vymazat chybu TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Barva není čistá"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Komunitní překl."
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Pokr."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Zchladit"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Kopírovat vybraný jazyk?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Náraz"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Det. nárazu"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Detekován náraz."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -398,34 +397,34 @@ msgstr ""
 "Normal módu"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Ustřihnout"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Stříhání"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Temný"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Vypnout"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Vypnout motory"
 
@@ -437,8 +436,8 @@ msgid "Disengaging idler"
 msgstr "Odpojuji idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -448,7 +447,7 @@ msgstr ""
 "manuálu, kapitola Začínáme."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -456,14 +455,14 @@ msgstr ""
 "Chcete opakovat poslední krok a pozměnit vzdálenost mezi tryskou a "
 "podložkou?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Konec"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "Korekce E"
 
@@ -492,7 +491,7 @@ msgid "ERR Wait for User"
 msgstr "ERR: Čekám na uživ."
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "CHYBA:"
 
@@ -504,17 +503,17 @@ msgid "Ejecting filament"
 msgstr "Vysouvám filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Koncový spínač"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Kon. spínač nesepnut"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Konc. spínače"
 
@@ -526,45 +525,45 @@ msgid "Engaging idler"
 msgstr "Zapínání idleru"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Extruder - info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "F. autozav."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "Det. záseku"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "F. runout"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT JE ZAVEDEN"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NESEPNULA"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -573,7 +572,7 @@ msgstr ""
 " že se filament nezasekl a FINDA funguje."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -582,65 +581,65 @@ msgstr ""
 " senzor ok?"
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA ZASEK. FILAM."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "FS reakce"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "F. SENZOR NESEPNUL"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "F.SENZOR MOC BRZY"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENZOR ZASEK FILAM."
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME CHYBA"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Selhání"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "Selhání MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Falešné spuštění"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Rychlost vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Test ventilátoru"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Kontr. vent."
 
@@ -669,46 +668,46 @@ msgid "Feeding to nozzle"
 msgstr "Zavádím do trysky"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Výpadky filam."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlačen a správné barvy?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Filament nezaveden"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -717,7 +716,7 @@ msgstr ""
 "filament může pohybovat a senzor funguje."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -726,7 +725,7 @@ msgstr ""
 "filament dostal a že senzor funguje."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -735,42 +734,42 @@ msgstr ""
 "nejsou nečistoty. Ujistěte se, že senzor funguje správně."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Spotřebováno filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "Soubor nekompletní. Pokračovat?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Dokončování pohybů"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Kal. první vrstvy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Nejdřív pomocí selftestu zkontoluji nejčastější chyby vznikající při "
 "sestavení tiskárny."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Průtok"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -779,28 +778,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Přední tiskový vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Vpředu [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Přední/levý vent."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code je připraven pro jinou verzi. Pokračovat?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -808,14 +807,14 @@ msgstr ""
 "G-code je připraven pro jinou verzi. Vyslicujte model znovu. Tisk zrušen."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code je připraven pro jiný typ tiskárny.Pokračovat?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -824,47 +823,47 @@ msgstr ""
 "zrušen."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code je pripraven pro novější FW. Pokračovat?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
 msgstr "G-code je připraven pro novější FW. Aktualizujte FW. Tisk zrušen."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "HW nastavení"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Topení/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Zahřívání"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Zahřívání přerušeno bezpečnostním časovačem."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Zahřívání OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -874,7 +873,7 @@ msgstr ""
 "nastavení, ve kterém zkalibrujeme osu Z. Pak budete moct začít tisknout."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -883,8 +882,8 @@ msgstr ""
 "kalibračním procesem?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Vys. výkon"
 
@@ -895,48 +894,48 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend má 280C! Tryska vyměněna a dotažena dle instrukcí?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Vent. hotendu:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Nyní provedu xyz kalibraci. Zabere to až 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Nyní provedu z kalibraci."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "IDLER: CHYBA HOMINGU"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "CHYBA POHYBU IDLERU"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "KONTROLA FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "NEPLATNÝ NÁSTROJ"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -945,307 +944,305 @@ msgstr ""
 "Tiskové pláty"
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Upřesňování kalibračního bodu"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Informace"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Zav. SD karty"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Vložte filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Vložte filament (nezavádějte) do extruderu a stiskněte tlačítko"
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Interní chyba. Zkuste resetovat MMU či aktualizujte FW."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Je filament zaveden?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Je tiskový plát na podložce?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Opakování"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Poslední tisk"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Selhání posl. tisku"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Vlevo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Levý vent na trysce?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Vlevo [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Normální"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Ztlumený"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Korekce lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Doladění osy Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Načíst vše"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Zavést filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Zavést do trysky"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Zatěžovací test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Čištění barvy"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Zavádění filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Uvolněná řemenička"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Hlasitý"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "AKTUALIZUJTE MMU FW"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Interní chyba MMU FW, resetujte MMU"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "MMU mód"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NEODPOVÍDÁ"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU opakování: Obnova teploty..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST SELHAL"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "Selhání MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "MMU selhání zav"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU neodpovídá správně. Zkontrolujte zapojení kabelu."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU neodpovídá. Zkontrolujte kabely a jejich zapojení."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU připojeno"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Komp. magnetu"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Hlavní nabídka"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Meřené zkos."
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Meřím referenční výšku kalibračního bodu"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Mesh Bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Mód"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Probíhá změna modu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Více info na webu"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Posunout X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Posunout Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Posunout Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Posunout osu"
 
@@ -1256,95 +1253,94 @@ msgid "Moving selector"
 msgstr "Přesun selektoru"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Vyšla nová verze FW:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Ne"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Žádná SD karta"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Bez pohybu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Žádné"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Nezapojeno"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Netočí se"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Nyní zkalibruji vzdálenost mezi koncem trysky a povrchem podložky."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nyní předehřeji trysku pro PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Nyní odstraňte testovací výtisk z tiskového plátu."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Tryska"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Výměna trysek"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Tryska"
 
@@ -1355,89 +1351,89 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Vyp"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Neplatné hodnoty nastavení. Bude použito výchozí PID, Esteps atd."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "Zap"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "Jednou"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "STOP: CHYBA TEPLOTY"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "PID kal. ukončena"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "PID kalibrace"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "Nahřívání PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibrace selhala"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr ""
-"PINDA kalibrace dokončena a je nyní aktivní. Lze deaktivovat v menu "
-"Nastavení->Tepl. kal."
+"PINDA kalibrace dokončena a je nyní aktivní. Lze deaktivovat v "
+"menu Nastavení->Tepl. kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "KLADKA SE NEOTÁČÍ"
 
@@ -1448,13 +1444,13 @@ msgid "Parking selector"
 msgstr "KLADKA SE NEOTÁČÍ"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Pozastavit tisk"
 
@@ -1465,7 +1461,7 @@ msgid "Performing cut"
 msgstr "Provádím řez"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1474,7 +1470,7 @@ msgstr ""
 "prvních 4 bodů. Pokud tryska zachyti papír, okamžitě vypněte tiskárnu."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1483,33 +1479,33 @@ msgstr ""
 "restartováním tiskárny."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Zkontrolujte zapojení IR senzoru a vyjmutý filament"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Zkontrolujte:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Očistěte podložku a stiskněte tlačítko."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pro úspěšnou kalibraci očistete trysku. Potvrďte tlačítkem."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Vložte filament do extruderu a stiskem tlačítka jej zavedete."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1517,104 +1513,104 @@ msgstr ""
 "Vložte filament do první trubičky MMU a stiskněte tlačítko k jeho zavedení."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Nejdřív zaveďte filament"
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Otevřete idler a manuálně odstraňte filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Umistěte tiskový plát na podložku"
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Pro vysunutí filamentu stiskněte tlačítko"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Vyjměte urychleně filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Nejprve sundejte transportní součástky."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Odstraňte tiskový plát z podložky."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Nejprve spusťte kalibraci XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vyjměte filament a zopakujte tuto akci"
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Prosím aktualizujte."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Čekejte"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Výpadky proudu"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Předehřev"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Předehřejte trysku!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Předehřev trysky. Vyčkejte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Předehřev ke střihu"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Předehřev k vysunutí"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Předehřev k zavedení"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Předehřev k vyjmutí"
 
@@ -1625,48 +1621,48 @@ msgid "Preparing blade"
 msgstr "Připravuji čepel"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Stiskněte tlačítko"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pro nahřátí trysky a pokračování stiskněte tlačítko."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Tisk přerušen"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Tiskový vent.:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Tisk z SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Tisk pozastaven"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Čas tisku"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "IP adr. tiskárny:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1675,12 +1671,12 @@ msgstr ""
 "Začínáme."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Průměr trysky tiskárny se liší od G-code. Pokračovat?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1689,7 +1685,7 @@ msgstr ""
 "zrušen."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Kladkový motor se zastavil. Ujistěte se, že není pohyb blokován a "
@@ -1702,32 +1698,32 @@ msgid "Pushing filament"
 msgstr "Posun filamentu"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "FRONTA PLNA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Vzadu [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Obnovování tisku"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Přejmenovat"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1736,24 +1732,24 @@ msgstr ""
 "nástrojový index mimo rozsah (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Pokračovat"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Obnovení tisku"
 
@@ -1764,7 +1760,7 @@ msgid "Retract from FINDA"
 msgstr "Vysouvání od FINDy"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Znovu"
 
@@ -1775,17 +1771,17 @@ msgid "Returning selector"
 msgstr "Vracím selektor"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Vpravo"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Vpravo [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1794,64 +1790,64 @@ msgstr ""
 "kalibrační proces od začátku. Pokračovat?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "SD karta"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELEKTOR: HOMING ERR"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELEKTOR SE NEHÝBE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "ZASTAVENO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Hledám kalibrační bod podložky"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Vybrat"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Zvolte filament pro kalibraci první vrstvy z následujícího menu"
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Zvolte filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Výběr jazyka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vyberte teplotu predehřátí trysky která odpovídá vašemu materiálu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Zvolte teplotu, která odpovídá vašemu materiálu."
 
@@ -1862,72 +1858,72 @@ msgid "Selecting fil. slot"
 msgstr "Výběr fil. slot"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Start Selftestu"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Chyba Selftestu!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Selftest selhal"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Pro kalibraci přesného rehomování bude nyní spuštěn selftest."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Senzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor ověřen, vyjměte filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Nastavte teplotu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Nastavení"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Težké zkos."
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Plát"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1940,23 +1936,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Stav konc. spín."
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Tichý"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Lehké zkos."
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1965,125 +1961,125 @@ msgstr ""
 "setříděni je 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Vyskytl se problém, srovnávám osu Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Řazení"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Řazení souborů"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Rychlost"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Točí se"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Je vyžadována stabilní pokojová teplota 21-26C a pevná podložka."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Tichý"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Tiskové pláty"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Zastavit tisk"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Přísně"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Podpora"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Prohozené"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "TEPLOTNÍ VÝJIMKA"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "CHYBA TMC DRIVER"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "TMC RESET DRIVERU"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRIVER: ZKRAT"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC CHYBA: PŘEHŘÁTÍ"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC CHYBA NÍZKÉ NAP."
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2092,27 +2088,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Termální model zatím nebyl kalibrován."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Teplota"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Teploty"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Testování filamentu"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2120,7 +2116,7 @@ msgstr ""
 "pohyb."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2128,7 +2124,7 @@ msgstr ""
 "pohyb."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2138,7 +2134,7 @@ msgstr ""
 "výšku. Postupujte podle obrázku v handbooku (kapitola Kalibrace)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2146,63 +2142,63 @@ msgstr ""
 "Je potřeba kalibrovat osu Z. Postupujte dle příručky, kapitola Začíname."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Čas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Celkem"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Celkem selhání"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Filament celkem"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Celkový čas tisku"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Ladit"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "MANUÁLNÍ VYJMUTÍ"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Vyjmout"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Vyjmout filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Vysouvám filament"
 
@@ -2219,23 +2215,23 @@ msgid "Unloading to pulley"
 msgstr "Vysunutí ke kladce"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Ověření selhalo, vyjměte filament a zkuste znovu."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Napětí"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "TMC: VYSOKA TEPLOTA!"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2248,199 +2244,205 @@ msgstr ""
 "Stealth módu"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Čeká se na uživatele"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Čekání na zchladnutí PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Čekání na zchladnutí trysky a podložky."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Varovat"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Varování: došlo ke změně typu tiskárny a motherboardu."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Varování: došlo ke změně typu motherboardu."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Varování: došlo ke změně typu tiskárny."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Bylo vysunutí filamentu úspěšné?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Chyba zapojení"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Průvodce"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "Korekce X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "Detaily XYZ kal."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Kalibrace XYZ v pořádku. Zkosení bude automaticky vyrovnáno při tisku."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibrace XYZ v pořádku. X/Y osy mírně zkosené. Dobrá práce!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibrace XYZ nepřesná. Přední kalibrační body moc vpředu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibrace XYZ nepřesná. Pravý přední bod moc vpředu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibrace XYZ selhala. Kalibrační bod podložky nenalezen."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Kalibrace XYZ selhala. Přední kalibrační body moc vpředu. Srovnejte "
 "tiskárnu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibrace XYZ selhala. Nahlédněte do manuálu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Kalibrace XYZ selhala. Pravý přední bod moc vpředu. Srovnejte tiskárnu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibrace XYZ v pořádku. X/Y osy jsou kolmé. Gratuluji!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Y vzdálenost od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Korekce Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Ano"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Průvodce můžete znovu spustit z menu Kalibrace -> Průvodce."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Korekce Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Počet měření Z"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] odsazení bodu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "a stiskněte tlačítko"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "k zavedení filamentu"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "k vyjmutí filamentu"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "neznámý"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "neznámý stav"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Obnovit"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "MMU vyp. proudu"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Vysunutí z MMU"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT VYSUNUT"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2449,12 +2451,12 @@ msgstr ""
 " Zkontrolujte snímače a kabeláž."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "NAČÍST DO EXTR. SEL."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2463,28 +2465,28 @@ msgstr ""
 "případě potřeby upřesněte kalibraci snímače."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU CHYBA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Výměn materiálů"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Odstraňte vysunuté filament z přední části MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2493,7 +2495,7 @@ msgstr ""
 " ve voliči není žádné vlákno a FINDA funguje správně."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2501,47 +2503,55 @@ msgstr ""
 "3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Zavést do MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "MK3 firmware detekován na MK3S tiskarně"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "MK3S firmware detekován na tiskarně MK3"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "NEZNÁMÁ CHYBA"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Došlo k neočekávané chybě."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Vysunout"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "VÝMĚNA FILAMENTU"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Zavést"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Výměna filamentu M600. Vložte nový filament nebo vysuňte starý."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Citlivost"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Mesh Bed Leveling selhal. Spusťte kalibraci osy Z."
 
@@ -2558,16 +2568,7 @@ msgstr "Zrušit Připravena"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Reprint"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Obnovit"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "MK3 firmware detekován na MK3S tiskarně"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "MK3S firmware detekován na tiskarně MK3"
+msgstr "Tisk. znovu"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2555,7 +2555,7 @@ msgstr "Připravit"
 msgid "Set not Ready"
 msgstr "Zrušit Připravena"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Reprint"

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 nebo starší"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 nebo novější"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "%s očekávaná verze"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Zrušit"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Doladění Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Vše OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Vše je hotovo. Tisku zdar!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Vždy"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Okolí"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "Dojely oba Z vozíky k-hornímu dorazu?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Automat."
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "AutoZavedení fil."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,52 +115,52 @@ msgid "Avoiding grind"
 msgstr "Eliminace obroušení"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Osa"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Délka osy"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Zpět"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Podložka"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Zahřívání bedu"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Bed OK."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Korekce podložky"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +168,54 @@ msgstr ""
 "Kalibrace Z selhala. Sensor nesepnul. Znečištená tryska? Čekám na reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Podložka/Topení"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Stav řemenu"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Test řemenu"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Detekován výpadek proudu. Obnovit tisk?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Jasný"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Podsvícení"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "CHYBA KOMUNIKACE"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Kalibrace XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Kalibrovat Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +224,13 @@ msgstr ""
 " tlačítkem."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Kalibruji Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,155 +239,155 @@ msgstr ""
 "tlacitkem."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Kalibruji výchozí p."
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Kalibrace"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Kalibrace OK"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Chyba pohybu selektoru nebo idleru"
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr "Nelze provést akci, filament je zaveden. Nejprve jej vyjměte."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "Karta vyjmuta"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Vyměňte SD kartu"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Vyměnit filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Změna úspěšná!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Výměna ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Kontrola osy X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Kontrola osy Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Kontrola osy Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Kontrola podložky"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Kontrola endstopů"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Kontroluji soubor"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Kontrola hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Kontrola senzorů"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Kontrola"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "Vymazat chybu TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Barva není čistá"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Komunitní překl."
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Pokr."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Zchladit"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Kopírovat vybraný jazyk?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Náraz"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Det. nárazu"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Detekován náraz."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -397,34 +398,34 @@ msgstr ""
 "Normal módu"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Ustřihnout"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Stříhání"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Temný"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Vypnout"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Vypnout motory"
 
@@ -436,8 +437,8 @@ msgid "Disengaging idler"
 msgstr "Odpojuji idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -447,7 +448,7 @@ msgstr ""
 "manuálu, kapitola Začínáme."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -455,14 +456,14 @@ msgstr ""
 "Chcete opakovat poslední krok a pozměnit vzdálenost mezi tryskou a "
 "podložkou?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Konec"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "Korekce E"
 
@@ -491,7 +492,7 @@ msgid "ERR Wait for User"
 msgstr "ERR: Čekám na uživ."
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "CHYBA:"
 
@@ -503,17 +504,17 @@ msgid "Ejecting filament"
 msgstr "Vysouvám filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Koncový spínač"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Kon. spínač nesepnut"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Konc. spínače"
 
@@ -525,45 +526,45 @@ msgid "Engaging idler"
 msgstr "Zapínání idleru"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Extruder - info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "F. autozav."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "Det. záseku"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "F. runout"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT JE ZAVEDEN"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NESEPNULA"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -572,7 +573,7 @@ msgstr ""
 " že se filament nezasekl a FINDA funguje."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -581,65 +582,65 @@ msgstr ""
 " senzor ok?"
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA ZASEK. FILAM."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "FS reakce"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "F. SENZOR NESEPNUL"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "F.SENZOR MOC BRZY"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENZOR ZASEK FILAM."
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME CHYBA"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Selhání"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "Selhání MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Falešné spuštění"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Rychlost vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Test ventilátoru"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Kontr. vent."
 
@@ -668,46 +669,46 @@ msgid "Feeding to nozzle"
 msgstr "Zavádím do trysky"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Výpadky filam."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlačen a správné barvy?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Filament nezaveden"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -716,7 +717,7 @@ msgstr ""
 "filament může pohybovat a senzor funguje."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -725,7 +726,7 @@ msgstr ""
 "filament dostal a že senzor funguje."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -734,42 +735,42 @@ msgstr ""
 "nejsou nečistoty. Ujistěte se, že senzor funguje správně."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Spotřebováno filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "Soubor nekompletní. Pokračovat?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Dokončování pohybů"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Kal. první vrstvy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Nejdřív pomocí selftestu zkontoluji nejčastější chyby vznikající při "
 "sestavení tiskárny."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Průtok"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -778,28 +779,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Přední tiskový vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Vpředu [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Přední/levý vent."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code je připraven pro jinou verzi. Pokračovat?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -807,14 +808,14 @@ msgstr ""
 "G-code je připraven pro jinou verzi. Vyslicujte model znovu. Tisk zrušen."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code je připraven pro jiný typ tiskárny.Pokračovat?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -823,47 +824,47 @@ msgstr ""
 "zrušen."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code je pripraven pro novější FW. Pokračovat?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
 msgstr "G-code je připraven pro novější FW. Aktualizujte FW. Tisk zrušen."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "HW nastavení"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Topení/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Zahřívání"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Zahřívání přerušeno bezpečnostním časovačem."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Zahřívání OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -873,7 +874,7 @@ msgstr ""
 "nastavení, ve kterém zkalibrujeme osu Z. Pak budete moct začít tisknout."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -882,8 +883,8 @@ msgstr ""
 "kalibračním procesem?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Vys. výkon"
 
@@ -894,48 +895,48 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend má 280C! Tryska vyměněna a dotažena dle instrukcí?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Vent. hotendu:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Nyní provedu xyz kalibraci. Zabere to až 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Nyní provedu z kalibraci."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "IDLER: CHYBA HOMINGU"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "CHYBA POHYBU IDLERU"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "KONTROLA FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "NEPLATNÝ NÁSTROJ"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -944,305 +945,307 @@ msgstr ""
 "Tiskové pláty"
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Upřesňování kalibračního bodu"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Informace"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Zav. SD karty"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Vložte filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Vložte filament (nezavádějte) do extruderu a stiskněte tlačítko"
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Interní chyba. Zkuste resetovat MMU či aktualizujte FW."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Je filament zaveden?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Je tiskový plát na podložce?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Opakování"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Poslední tisk"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Selhání posl. tisku"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Vlevo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Levý vent na trysce?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Vlevo [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Normální"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Ztlumený"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Korekce lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Doladění osy Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Načíst vše"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Zavést filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Zavést do trysky"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Zatěžovací test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Čištění barvy"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Zavádění filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Uvolněná řemenička"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Hlasitý"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "AKTUALIZUJTE MMU FW"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Interní chyba MMU FW, resetujte MMU"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "MMU mód"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NEODPOVÍDÁ"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU opakování: Obnova teploty..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST SELHAL"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "Selhání MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "MMU selhání zav"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU neodpovídá správně. Zkontrolujte zapojení kabelu."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU neodpovídá. Zkontrolujte kabely a jejich zapojení."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU připojeno"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Komp. magnetu"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Hlavní nabídka"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Meřené zkos."
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Meřím referenční výšku kalibračního bodu"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Mesh Bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Mód"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Probíhá změna modu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Více info na webu"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Posunout X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Posunout Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Posunout Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Posunout osu"
 
@@ -1253,94 +1256,95 @@ msgid "Moving selector"
 msgstr "Přesun selektoru"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Vyšla nová verze FW:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Ne"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Žádná SD karta"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Bez pohybu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Žádné"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Nezapojeno"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Netočí se"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Nyní zkalibruji vzdálenost mezi koncem trysky a povrchem podložky."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nyní předehřeji trysku pro PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Nyní odstraňte testovací výtisk z tiskového plátu."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Tryska"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Výměna trysek"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Tryska"
 
@@ -1351,80 +1355,80 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Vyp"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Neplatné hodnoty nastavení. Bude použito výchozí PID, Esteps atd."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "Zap"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "Jednou"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "STOP: CHYBA TEPLOTY"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "PID kal. ukončena"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "PID kalibrace"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "Nahřívání PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibrace selhala"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1433,7 +1437,7 @@ msgstr ""
 "Nastavení->Tepl. kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "KLADKA SE NEOTÁČÍ"
 
@@ -1444,13 +1448,13 @@ msgid "Parking selector"
 msgstr "KLADKA SE NEOTÁČÍ"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Pozastavit tisk"
 
@@ -1461,7 +1465,7 @@ msgid "Performing cut"
 msgstr "Provádím řez"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1470,7 +1474,7 @@ msgstr ""
 "prvních 4 bodů. Pokud tryska zachyti papír, okamžitě vypněte tiskárnu."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1479,33 +1483,33 @@ msgstr ""
 "restartováním tiskárny."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Zkontrolujte zapojení IR senzoru a vyjmutý filament"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Zkontrolujte:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Očistěte podložku a stiskněte tlačítko."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pro úspěšnou kalibraci očistete trysku. Potvrďte tlačítkem."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Vložte filament do extruderu a stiskem tlačítka jej zavedete."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1513,104 +1517,104 @@ msgstr ""
 "Vložte filament do první trubičky MMU a stiskněte tlačítko k jeho zavedení."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Nejdřív zaveďte filament"
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Otevřete idler a manuálně odstraňte filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Umistěte tiskový plát na podložku"
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Pro vysunutí filamentu stiskněte tlačítko"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Vyjměte urychleně filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Nejprve sundejte transportní součástky."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Odstraňte tiskový plát z podložky."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Nejprve spusťte kalibraci XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vyjměte filament a zopakujte tuto akci"
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Prosím aktualizujte."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Čekejte"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Výpadky proudu"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Předehřev"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Předehřejte trysku!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Předehřev trysky. Vyčkejte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Předehřev ke střihu"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Předehřev k vysunutí"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Předehřev k zavedení"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Předehřev k vyjmutí"
 
@@ -1621,48 +1625,48 @@ msgid "Preparing blade"
 msgstr "Připravuji čepel"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Stiskněte tlačítko"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pro nahřátí trysky a pokračování stiskněte tlačítko."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Tisk přerušen"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Tiskový vent.:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Tisk z SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Tisk pozastaven"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Čas tisku"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "IP adr. tiskárny:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1671,12 +1675,12 @@ msgstr ""
 "Začínáme."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Průměr trysky tiskárny se liší od G-code. Pokračovat?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1685,7 +1689,7 @@ msgstr ""
 "zrušen."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Kladkový motor se zastavil. Ujistěte se, že není pohyb blokován a "
@@ -1698,32 +1702,32 @@ msgid "Pushing filament"
 msgstr "Posun filamentu"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "FRONTA PLNA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Vzadu [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Obnovování tisku"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Přejmenovat"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1732,24 +1736,24 @@ msgstr ""
 "nástrojový index mimo rozsah (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Pokračovat"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Obnovení tisku"
 
@@ -1760,7 +1764,7 @@ msgid "Retract from FINDA"
 msgstr "Vysouvání od FINDy"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Znovu"
 
@@ -1771,17 +1775,17 @@ msgid "Returning selector"
 msgstr "Vracím selektor"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Vpravo"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Vpravo [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1790,64 +1794,64 @@ msgstr ""
 "kalibrační proces od začátku. Pokračovat?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "SD karta"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELEKTOR: HOMING ERR"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELEKTOR SE NEHÝBE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "ZASTAVENO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Hledám kalibrační bod podložky"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Vybrat"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Zvolte filament pro kalibraci první vrstvy z následujícího menu"
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Zvolte filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Výběr jazyka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vyberte teplotu predehřátí trysky která odpovídá vašemu materiálu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Zvolte teplotu, která odpovídá vašemu materiálu."
 
@@ -1858,72 +1862,72 @@ msgid "Selecting fil. slot"
 msgstr "Výběr fil. slot"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Start Selftestu"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Chyba Selftestu!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Selftest selhal"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Pro kalibraci přesného rehomování bude nyní spuštěn selftest."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Senzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor ověřen, vyjměte filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Nastavte teplotu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Nastavení"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Težké zkos."
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Plát"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1936,23 +1940,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Stav konc. spín."
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Tichý"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Lehké zkos."
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1961,125 +1965,125 @@ msgstr ""
 "setříděni je 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Vyskytl se problém, srovnávám osu Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Řazení"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Řazení souborů"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Rychlost"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Točí se"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Je vyžadována stabilní pokojová teplota 21-26C a pevná podložka."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Tichý"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Tiskové pláty"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Zastavit tisk"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Přísně"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Podpora"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Prohozené"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "TEPLOTNÍ VÝJIMKA"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "CHYBA TMC DRIVER"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "TMC RESET DRIVERU"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRIVER: ZKRAT"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC CHYBA: PŘEHŘÁTÍ"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC CHYBA NÍZKÉ NAP."
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2088,27 +2092,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Termální model zatím nebyl kalibrován."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Teplota"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Teploty"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Testování filamentu"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2116,7 +2120,7 @@ msgstr ""
 "pohyb."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 "pohyb."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2134,7 +2138,7 @@ msgstr ""
 "výšku. Postupujte podle obrázku v handbooku (kapitola Kalibrace)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2142,63 +2146,63 @@ msgstr ""
 "Je potřeba kalibrovat osu Z. Postupujte dle příručky, kapitola Začíname."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Čas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Celkem"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Celkem selhání"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Filament celkem"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Celkový čas tisku"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Ladit"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "MANUÁLNÍ VYJMUTÍ"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Vyjmout"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Vyjmout filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Vysouvám filament"
 
@@ -2215,23 +2219,23 @@ msgid "Unloading to pulley"
 msgstr "Vysunutí ke kladce"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Ověření selhalo, vyjměte filament a zkuste znovu."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Napětí"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "TMC: VYSOKA TEPLOTA!"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2244,205 +2248,199 @@ msgstr ""
 "Stealth módu"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Čeká se na uživatele"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Čekání na zchladnutí PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Čekání na zchladnutí trysky a podložky."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Varovat"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Varování: došlo ke změně typu tiskárny a motherboardu."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Varování: došlo ke změně typu motherboardu."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Varování: došlo ke změně typu tiskárny."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Bylo vysunutí filamentu úspěšné?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Chyba zapojení"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Průvodce"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "Korekce X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "Detaily XYZ kal."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Kalibrace XYZ v pořádku. Zkosení bude automaticky vyrovnáno při tisku."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibrace XYZ v pořádku. X/Y osy mírně zkosené. Dobrá práce!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibrace XYZ nepřesná. Přední kalibrační body moc vpředu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibrace XYZ nepřesná. Pravý přední bod moc vpředu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibrace XYZ selhala. Kalibrační bod podložky nenalezen."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Kalibrace XYZ selhala. Přední kalibrační body moc vpředu. Srovnejte "
 "tiskárnu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibrace XYZ selhala. Nahlédněte do manuálu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Kalibrace XYZ selhala. Pravý přední bod moc vpředu. Srovnejte tiskárnu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibrace XYZ v pořádku. X/Y osy jsou kolmé. Gratuluji!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Y vzdálenost od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Korekce Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Ano"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Průvodce můžete znovu spustit z menu Kalibrace -> Průvodce."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Korekce Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Počet měření Z"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] odsazení bodu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "a stiskněte tlačítko"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "k zavedení filamentu"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "k vyjmutí filamentu"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "neznámý"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "neznámý stav"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Obnovit"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "MMU vyp. proudu"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Vysunutí z MMU"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT VYSUNUT"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2451,12 +2449,12 @@ msgstr ""
 " Zkontrolujte snímače a kabeláž."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "NAČÍST DO EXTR. SEL."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2465,28 +2463,28 @@ msgstr ""
 "případě potřeby upřesněte kalibraci snímače."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU CHYBA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Výměn materiálů"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Odstraňte vysunuté filament z přední části MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2495,7 +2493,7 @@ msgstr ""
 " ve voliči není žádné vlákno a FINDA funguje správně."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2503,55 +2501,47 @@ msgstr ""
 "3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Zavést do MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "MK3 firmware detekován na MK3S tiskarně"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "MK3S firmware detekován na tiskarně MK3"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "NEZNÁMÁ CHYBA"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Došlo k neočekávané chybě."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Vysunout"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "VÝMĚNA FILAMENTU"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Zavést"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Výměna filamentu M600. Vložte nový filament nebo vysuňte starý."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Citlivost"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Mesh Bed Leveling selhal. Spusťte kalibraci osy Z."
 
@@ -2566,9 +2556,18 @@ msgid "Set not Ready"
 msgstr "Zrušit Připravena"
 
 #. MSG_REPRINT c=7
-#: ../../Firmware/ultralcd.cpp:5189
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Reprint"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Obnovit"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "MK3 firmware detekován na MK3S tiskarně"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "MK3S firmware detekován na tiskarně MK3"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2593,6 +2593,11 @@ msgstr "Bereit setzen"
 msgid "Set not Ready"
 msgstr "Nicht breit setzen"
 
+#. MSG_REPRINT c=7
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Abdruck"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Entferne das alte Fil. und drücke den Knopf, um das neue zu laden."
 

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 oder älter"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 oder neuer"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "%s Level erwartet"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Abbruch"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Z Anpassen"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Alles richtig"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Alles abgeschlossen. Viel Spaß beim Drucken!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Alphabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Immer"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Raumtemp."
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "Sind linker+rechter Z-Schlitten ganz oben?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Startposition"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Auto Leist"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "AutoLaden Filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -115,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Vermeide schleifen"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Achse"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Achsenlänge"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Zurück"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Bett"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Bett aufwärmen"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Bett OK"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Bett Level Korr."
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -169,54 +168,54 @@ msgstr ""
 "Reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Bett/Heizung"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Gurtstatus"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Riementest"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Stromausfall! Druck wiederherstellen?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Hell"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Helligkeit"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "KOMMUNIKATIONSFEHLER"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "XYZ Kalibrierung"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Z Kalibrierung"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -225,13 +224,13 @@ msgstr ""
 "Anschliessend den Knopf drücken."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Kalibriere Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -240,28 +239,28 @@ msgstr ""
 "Anschliessend den Knopf drücken."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Kalibriere Start"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Kalibrierung"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Kalibrierung OK"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Kann Selektor oder Riemenscheibe nicht bewegen."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
@@ -269,128 +268,128 @@ msgstr ""
 "Entladen Sie es zuerst."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "SD Karte entfernt"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Wechsel SD Karte"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Filament-Wechsel"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Wechsel erfolgreich!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Wechsel ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Prüfe X Achse"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Prüfe Y Achse"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Prüfe Z Achse"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Prüfe Bett"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Prüfe Endschalter"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Überprüfe Datei"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Prüfe Düse"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Prüfe Sensoren"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Kontrolle"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "TM Fehler löschen"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Falsche Farbe"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Von der Community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Weit."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Abkühlen"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Gewählte Sprache kopieren?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Crash Erk."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Crash erkannt."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -401,34 +400,34 @@ msgstr ""
 "genutzt werden"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Fil. schneiden"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Messer"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Dimm"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Deaktiv."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Motoren aus"
 
@@ -440,8 +439,8 @@ msgid "Disengaging idler"
 msgstr "Spannrol. auskuppeln"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -451,21 +450,21 @@ msgstr ""
 "eingestellt. Folgen Sie dem Handbuch, Kapitel Erste Schritte."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 "Willst du den letzten Schritt wiederholen, um den Abstand neu einzustellen?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Klar"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "E-Korrektur"
 
@@ -494,7 +493,7 @@ msgid "ERR Wait for User"
 msgstr "FEHL. Warte Benutzer"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "FEHLER:"
 
@@ -506,17 +505,17 @@ msgid "Ejecting filament"
 msgstr "Werfe Filament aus"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Endschalter"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Ende nicht getroffen"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Endschalter"
 
@@ -528,54 +527,54 @@ msgid "Engaging idler"
 msgstr "Spannrol. einkuppeln"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Extruder Info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "F. autoladen"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "F. Stau entd."
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "FS. Auslauf"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FIL. BEREITS GELADEN"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA N. AUSGELÖST"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
 msgstr ""
-"FINDA nicht ausgeschaltet beim Entladen. Entlade Fil. manuell. Bewegt sich "
-"Fil.? Funktioniert FINDA?"
+"FINDA nicht ausgeschaltet beim Entladen. Entlade Fil. manuell. Bewegt sich"
+" Fil.? Funktioniert FINDA?"
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -584,65 +583,65 @@ msgstr ""
 " sich das Filament bewegen kann und FINDA funktioniert."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA NICHT FIL.FREI"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "FS Aktion"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR N. AUSGELÖST"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR ZU FRÜH"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR N. FIL.FREI"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "FW-LAUFZEITFEHLER"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Fehlerstatistik"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "MMU-Fehler"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Fehlauslösung"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Lüfter-Tempo"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Lüftertest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Lüfter Check"
 
@@ -671,46 +670,46 @@ msgid "Feeding to nozzle"
 msgstr "Zufuhr zur Düse"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Fil. Mängel"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Fil. Sensor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrudiert mit richtiger Farbe?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Fil. nicht geladen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Filament-Sensor"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -719,7 +718,7 @@ msgstr ""
 "Sensor funktioniert?"
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -729,7 +728,7 @@ msgstr ""
 "funktioniert."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -738,42 +737,42 @@ msgstr ""
 "dass nichts im PTFE-Schlauch fest- sitzt und der Sensor richtig liest."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Filament benutzt"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "Datei unvollständig. Trotzdem fortfahren?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Bewegungen beenden"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Erste-Schicht Kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Zunächst führe ich den Selbsttest durch, um die häufigsten Probleme beim "
 "Zusammenbau zu überprüfen."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Durchfluss"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -782,28 +781,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Vorderer Lüfter?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Vorne [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Druck/Hotend Lüfter"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-Code ist für einen anderen Level geslict. Fortfahren?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -812,14 +811,14 @@ msgstr ""
 "Druck abgebrochen."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-Code ist für einen anderen Drucker geslict. Fortfahren?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -828,12 +827,12 @@ msgstr ""
 "Druck abgebrochen."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-Code ist für eine neuere Firmware geslict. Fortfahren?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -842,35 +841,35 @@ msgstr ""
 "Druck abgebrochen."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "HW Einstellungen"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Heizung/Thermistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Aufwärmen"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Heizung durch Sicherheitstimer deaktiviert."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Aufwärmen OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -881,7 +880,7 @@ msgstr ""
 "Danach können Sie drucken."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -890,8 +889,8 @@ msgstr ""
 "durch den Einricht- ungsablauf führe?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Hohe Leist"
 
@@ -902,50 +901,50 @@ msgid "Homing"
 msgstr "Startposition"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend bei 280C! Düse gewechselt, gemäß Spezifikation angezogen?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Hotend-Lüfter:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr ""
 "Ich werde jetzt die XYZ-Kalibrierung durchführen. Es kan bis zu 24 "
 "Min.dauern."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Ich werde jetzt die Z Kalibrierung durchführen."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "SPANNRO. STARTP.FEH."
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "SPANNROL. SITZT FEST"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "INSPIZIERE FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "UNGÜLTIGER FIL.PLATZ"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -954,27 +953,27 @@ msgstr ""
 "stellungen unter Einstellungen - HW Setup - Stahlbleche."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Verbesserung des Bettkalibrierungs- punkts"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Infoanzeige"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Init. SD Karte"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Filament einlegen"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -983,284 +982,282 @@ msgstr ""
 "den Knopf."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
 "Interner Laufzeitfehler. MMU zurücksetzen oder Firmware aktualisieren."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Ist Filament geladen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Liegt Stahlblech auf dem Heizbett?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Wiederholung"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Letzter Druck"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Letzte Druckfehler"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Links"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Linker Lüfter?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Links [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Hell.wert"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Dimmwert"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Lineare Korrektur"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Z einstellen"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Alle laden"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Filament laden"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "In Düse laden"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Lade Filament Test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Lade Farbe"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Filament lädt"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Lose Riemenscheibe"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Laut"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW UPDATE NÖTIG"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware Fehler, setzen Sie die MMU zurück."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "MMU Mod."
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU REAGIERT NICHT"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU-Neuversuch: Stelle die Tempera- tur wieder her..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELBSTTEST FEHL."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "MMU Fehler"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "MMU Ladefehler"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr ""
 "MMU antwortet nicht korrekt. Überprüfen Sie die Verkabelung und die "
 "Anschlüsse."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr ""
 "MMU antwortet nicht. Überprüfen Sie die Verkabelung und die Anschlüsse."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU verbunden"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Magnet Komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Hauptmenü"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Schräglauf"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Messen der Referenzhöhe des Kalibrierpunktes"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Gitter"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "MeshBett Ausgleich"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Modus"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Moduswechsel erfolgt..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Weitere Details online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Bewege X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Bewege Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Bewege Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Achse bewegen"
 
@@ -1271,95 +1268,94 @@ msgid "Moving selector"
 msgstr "Bewege Selektor"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/V"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Neue Firmware- Version verfügbar:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Nein"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Keine SD Karte"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Keine Bewegung."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Ohne"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Nicht angeschlossen"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Dreht sich nicht"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Jetzt kalibriere ich den Abstand zwischen Düsenspitze und Druckbett."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jetzt werde ich die Düse für PLA vorheizen."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Testdruck jetzt vom Stahlblech entfernen."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Düse"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Düsenwechsel"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Düsen Dia."
 
@@ -1370,81 +1366,81 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Aus"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Alte Einstellungen gefunden. Standard PID, E-Steps u.s.w. werden gesetzt."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "An"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "Einmal"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSE THERM. FEHLER"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "PID Kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "PID Kalib. fertig"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "PID Kalibrierung"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "PINDA erwärmen"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "PINDA Kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "PINDA-Kalibrierung fehlgeschlagen"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1453,7 +1449,7 @@ msgstr ""
 "Menü Einstellungen -> PINDA kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "RIEHMENS. SITZT FEST"
 
@@ -1464,13 +1460,13 @@ msgid "Parking selector"
 msgstr "Parke Selektor"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Druck pausieren"
 
@@ -1481,7 +1477,7 @@ msgid "Performing cut"
 msgstr "Führe Schnitt aus"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1490,7 +1486,7 @@ msgstr ""
 "ersten 4 Punkte. Drucker sofort aus- schalten, wenn das Papier erfasst wird."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1499,28 +1495,28 @@ msgstr ""
 "dem Assistenten fort, indem Sie den Drucker neu starten."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "IR Sensor Verbindungen über- prüfen. Ist Filament entladen?"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Prüfen:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Reinigen Sie das Heizbett und drücken Sie dann den Knopf."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 "Entfernen Sie überstehendes Filament von der Düse. Klicken wenn sauber."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1528,7 +1524,7 @@ msgstr ""
 "laden."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1537,104 +1533,104 @@ msgstr ""
 "den Knopf, um es zu laden."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Laden Sie zuerst das Filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Spannrolle öffnen und Filament von Hand entfernen"
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Legen Sie das Stahlblech auf das Heizbett."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Drücken Sie den Knopf um das Filament zu entladen."
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Ziehen Sie das Filament sofort heraus"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Zuerst Transportsicherungen entfernen."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Entfernen Sie das Stahlblech vom Heizbett."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Zuerst XYZ Kalibrierung ausführen."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Entladen Sie erst das Filament und versuchen Sie es nochmal."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Bitte aktualisieren."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Warten"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Netzfehler"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Vorheizen"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Düse vorheizen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Vorheizen der Düse. Bitte warten."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Heizen zum Schnitt"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Heizen zum Auswurf"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Heizen zum Laden"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Heizen zum Entladen"
 
@@ -1645,48 +1641,48 @@ msgid "Preparing blade"
 msgstr "Bereite Messer vor"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Knopf drücken zum"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Drücken Sie den Knopf um die Düse vorzuheizen und fortzufahren."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Druck abgebrochen"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Drucklüfter:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Drucken von SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Druck pausiert"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Druckzeit"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Drucker IP Adr.:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1695,12 +1691,12 @@ msgstr ""
 "Schritte."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Düsendurchmesser weicht vom G-Code ab. Fortfahren?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1709,7 +1705,7 @@ msgstr ""
 "den Wert in den Einstellungen. Druck abgebrochen."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Der Riemenscheiben- motor ist blockiert. Sicherstellen, dass sich die "
@@ -1722,32 +1718,32 @@ msgid "Pushing filament"
 msgstr "Schiebe Filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "QUEUE VOLL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Hinten [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Druck wiederherstel."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Umbenennen"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1756,24 +1752,24 @@ msgstr ""
 "Prüfen Sie den G-Code auf Plätze außerhalb des Bereichs (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ Kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Druck fortsetzen"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Druck fortgesetzt"
 
@@ -1784,7 +1780,7 @@ msgid "Retract from FINDA"
 msgstr "Einziehen von FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Wdh."
 
@@ -1795,17 +1791,17 @@ msgid "Returning selector"
 msgstr "Selektor zurückfahr."
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Rechts"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Rechts [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1814,39 +1810,39 @@ msgstr ""
 "beginnen. Fortfahren?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "SD Karte"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELEK. STARTPOSFEHL."
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELEKTOR SITZT FEST"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "GESTOPPT."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Suche Bett Kalibrierpunkt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Auswahl"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1855,25 +1851,25 @@ msgstr ""
 " im On-Screen-Menü aus."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Wähle filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Wähle Sprache"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vorheiztemperatur auswählen, die Ihrem Material entspricht."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Wählen Sie die Temperatur, die zu Ihrem Material passt."
 
@@ -1884,72 +1880,72 @@ msgid "Selecting fil. slot"
 msgstr "Wähle Filament Platz"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Selbsttest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Selbsttest start"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Selbsttest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Selbsttest Fehler!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Selbsttest Error"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Selbsttest wird gestartet, um Startposition zu kalibrieren."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Sensor Info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "FSensor überprüft, entladen Sie jetzt das Filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Temp. einstellen:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Einstellungen"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Sehr schräg"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Stahlblech"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1962,23 +1958,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Endschalter Status"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Leise"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Leicht schräg"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1986,126 +1982,126 @@ msgstr ""
 "Einige Dateien wur- den nicht sortiert. Max. Dateien pro Verzeichnis = 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Fehler aufgetreten, Z-Kalibrierung erforderlich..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Sort."
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Sortiere Dateien"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Ton"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Tempo"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Dreht sich"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Stabile Umgebungs- temperatur 21-26C und feste Stand- fläche erforderlich."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statistiken"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Leise"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Stahlbleche"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Druck abbrechen"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Ausgetauscht"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "THERMISCHE ANOMALIE"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "TMC TREIBER FEHLER"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "TMC TREIBER RESET"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC KURZSCHLUSS"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC ÜBERHITZ.FEHL."
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNTERSPANN.FEHL."
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2114,27 +2110,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Thermomodell noch nicht kalibriert."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Temperaturen"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Teste filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2142,13 +2138,13 @@ msgstr ""
 "ob irgendetwas dessen Bewegung blockiert."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr "Selektor erreicht Startpos. nicht. Prüf, ob etwas blockiert."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2159,7 +2155,7 @@ msgstr ""
 "im Handbuch."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2168,63 +2164,63 @@ msgstr ""
 " Schritte."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Zeit"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Gesamt"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Gesamte Fehler"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Gesamtes Filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Gesamte Druckzeit"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Anpassen"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "ENTLADE MANUELL"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Entla."
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Fil. entladen"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Filament auswerfen"
 
@@ -2241,25 +2237,25 @@ msgid "Unloading to pulley"
 msgstr "Entlade zur Riemens."
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 "Überprüfung fehl- geschlagen, entladen Sie das Filament und nochmals "
 "versuchen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Spannungen"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "WARNUNG TMC ZU HEISS"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2272,203 +2268,209 @@ msgstr ""
 "Stealth Modus"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Warte auf Benutzer.."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Warte bis PINDA- Sonde abgekühlt ist"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Warte bis Heizung und Bett abgekühlt sind"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Warnen"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Warnung: Druckertyp und Platinentyp wurden beide geändert."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Warnung: Platinentyp wurde geändert."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Warnung: Druckertyp wurde geändert."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Konnten Sie das Filament entnehmen?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Verdrahtungsfehler"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Assistent"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "X-Korrektur"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "XYZ Kal. Details"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ Kalibrierung in Ordnung. Schräglauf wird automatisch korrigiert."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "XYZ Kalibrierung in Ordnung. X/Y Achsen sind etwas schräg. Gut gemacht!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "XYZ-Kalibrierung beeinträchtigt. Vordere Kal.-Punkte nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-Kalibrierung beeinträchtigt. Kal. -Punkt vorne rechts nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bett-Kalibrierpunkt nicht gefunden."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "XYZ-Kalibrierung fehlgeschlagen. Vordere Kal.-Punkte nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-Kalibrierung fehlgeschlagen - mehr im Handbuch."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "XYZ-Kalibrierung fehlgeschlagen. Kal. -Punkt vorne rechts nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 "XYZ-Kalibrierung ok. X/Y-Achsen sind senkrecht zueinander Glückwunsch!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Y Entfernung vom Min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Y-Korrektur"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Im Menü Kalibrierung -> Assistent können Sie den Assistenten immer neu "
 "starten."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Z-Korrektur"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Z-Test Nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] Punktversatz"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "und Knopf drücken"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "um Filament laden"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "um Filament entladen"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "unbekannt"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "Status unbekannt"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Aktualisiere"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "MMU Netzfehler"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Aus MMU auswerf."
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT AUSGEWORFEN"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2477,12 +2479,12 @@ msgstr ""
 "ist. Überprüfen Sie die Sensoren und die Verkabelung."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "FEHL LADEN ZUM EXTR:"
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2491,85 +2493,93 @@ msgstr ""
 " Verfeiner die Sensorkalibrierung, falls erforderlich."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU FEHLER"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Materialwechsel"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Entfernen Sie das ausgeworfene Filament von der Vorderseite der MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
 msgstr ""
-"Selektor kann sich nicht bewegen, da FINDA Fil. erkannt hat. Stelle sicher, "
-"dass sich kein Fil. im Selektor befindet und FINDA richtig funktioniert."
+"Selektor kann sich nicht bewegen, da FINDA Fil. erkannt hat. Stelle sicher,"
+" dass sich kein Fil. im Selektor befindet und FINDA richtig funktioniert."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr "MMU FW ist inkompatibel mit Drucker FW. Update auf Version 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "In MMU laden"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "MK3-Firmware am MK3S-Drucker erkannt"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "MK3S-Firmware auf MK3-Drucker erkannt"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "UNBEKANNTER FEHLER"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Ein unerwarteter Fehler ist aufgetreten."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Auswerf."
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "FILAMENTWECHSEL"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Laden"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "M600 Filamentwechsel. Laden Sie ein neues Filament oder werfen Sie das alte "
 "aus."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Sensitivität"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "MeshBett Ausgleich fehlgeschlagen. Z Kalibrierung ausführen."
 
@@ -2586,16 +2596,7 @@ msgstr "Nicht breit setzen"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Abdruck"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Aktualisiere"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "MK3-Firmware am MK3S-Drucker erkannt"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "MK3S-Firmware auf MK3-Drucker erkannt"
+msgstr "Druck wiederholen"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Entferne das alte Fil. und drücke den Knopf, um das neue zu laden."

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 oder älter"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 oder neuer"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "%s Level erwartet"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Abbruch"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Z Anpassen"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Alles richtig"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Alles abgeschlossen. Viel Spaß beim Drucken!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Alphabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Immer"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Raumtemp."
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "Sind linker+rechter Z-Schlitten ganz oben?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Startposition"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Auto Leist"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "AutoLaden Filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,52 +115,52 @@ msgid "Avoiding grind"
 msgstr "Vermeide schleifen"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Achse"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Achsenlänge"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Zurück"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Bett"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Bett aufwärmen"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Bett OK"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Bett Level Korr."
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -168,54 +169,54 @@ msgstr ""
 "Reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Bett/Heizung"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Gurtstatus"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Riementest"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Stromausfall! Druck wiederherstellen?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Hell"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Helligkeit"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "KOMMUNIKATIONSFEHLER"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "XYZ Kalibrierung"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Z Kalibrierung"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -224,13 +225,13 @@ msgstr ""
 "Anschliessend den Knopf drücken."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Kalibriere Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -239,28 +240,28 @@ msgstr ""
 "Anschliessend den Knopf drücken."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Kalibriere Start"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Kalibrierung"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Kalibrierung OK"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Kann Selektor oder Riemenscheibe nicht bewegen."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
@@ -268,128 +269,128 @@ msgstr ""
 "Entladen Sie es zuerst."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "SD Karte entfernt"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Wechsel SD Karte"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Filament-Wechsel"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Wechsel erfolgreich!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Wechsel ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Prüfe X Achse"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Prüfe Y Achse"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Prüfe Z Achse"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Prüfe Bett"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Prüfe Endschalter"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Überprüfe Datei"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Prüfe Düse"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Prüfe Sensoren"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Kontrolle"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "TM Fehler löschen"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Falsche Farbe"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Von der Community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Weit."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Abkühlen"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Gewählte Sprache kopieren?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Crash Erk."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Crash erkannt."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -400,34 +401,34 @@ msgstr ""
 "genutzt werden"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Fil. schneiden"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Messer"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Dimm"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Deaktiv."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Motoren aus"
 
@@ -439,8 +440,8 @@ msgid "Disengaging idler"
 msgstr "Spannrol. auskuppeln"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -450,21 +451,21 @@ msgstr ""
 "eingestellt. Folgen Sie dem Handbuch, Kapitel Erste Schritte."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 "Willst du den letzten Schritt wiederholen, um den Abstand neu einzustellen?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Klar"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "E-Korrektur"
 
@@ -493,7 +494,7 @@ msgid "ERR Wait for User"
 msgstr "FEHL. Warte Benutzer"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "FEHLER:"
 
@@ -505,17 +506,17 @@ msgid "Ejecting filament"
 msgstr "Werfe Filament aus"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Endschalter"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Ende nicht getroffen"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Endschalter"
 
@@ -527,45 +528,45 @@ msgid "Engaging idler"
 msgstr "Spannrol. einkuppeln"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Extruder Info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "F. autoladen"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "F. Stau entd."
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "FS. Auslauf"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FIL. BEREITS GELADEN"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA N. AUSGELÖST"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -574,7 +575,7 @@ msgstr ""
 "Fil.? Funktioniert FINDA?"
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -583,65 +584,65 @@ msgstr ""
 " sich das Filament bewegen kann und FINDA funktioniert."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA NICHT FIL.FREI"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "FS Aktion"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR N. AUSGELÖST"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR ZU FRÜH"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR N. FIL.FREI"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "FW-LAUFZEITFEHLER"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Fehlerstatistik"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "MMU-Fehler"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Fehlauslösung"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Lüfter-Tempo"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Lüftertest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Lüfter Check"
 
@@ -670,46 +671,46 @@ msgid "Feeding to nozzle"
 msgstr "Zufuhr zur Düse"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Fil. Mängel"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Fil. Sensor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrudiert mit richtiger Farbe?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Fil. nicht geladen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Filament-Sensor"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -718,7 +719,7 @@ msgstr ""
 "Sensor funktioniert?"
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -728,7 +729,7 @@ msgstr ""
 "funktioniert."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -737,42 +738,42 @@ msgstr ""
 "dass nichts im PTFE-Schlauch fest- sitzt und der Sensor richtig liest."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Filament benutzt"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "Datei unvollständig. Trotzdem fortfahren?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Bewegungen beenden"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Erste-Schicht Kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Zunächst führe ich den Selbsttest durch, um die häufigsten Probleme beim "
 "Zusammenbau zu überprüfen."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Durchfluss"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -781,28 +782,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Vorderer Lüfter?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Vorne [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Druck/Hotend Lüfter"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-Code ist für einen anderen Level geslict. Fortfahren?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -811,14 +812,14 @@ msgstr ""
 "Druck abgebrochen."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-Code ist für einen anderen Drucker geslict. Fortfahren?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -827,12 +828,12 @@ msgstr ""
 "Druck abgebrochen."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-Code ist für eine neuere Firmware geslict. Fortfahren?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -841,35 +842,35 @@ msgstr ""
 "Druck abgebrochen."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "HW Einstellungen"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Heizung/Thermistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Aufwärmen"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Heizung durch Sicherheitstimer deaktiviert."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Aufwärmen OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -880,7 +881,7 @@ msgstr ""
 "Danach können Sie drucken."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -889,8 +890,8 @@ msgstr ""
 "durch den Einricht- ungsablauf führe?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Hohe Leist"
 
@@ -901,50 +902,50 @@ msgid "Homing"
 msgstr "Startposition"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend bei 280C! Düse gewechselt, gemäß Spezifikation angezogen?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Hotend-Lüfter:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr ""
 "Ich werde jetzt die XYZ-Kalibrierung durchführen. Es kan bis zu 24 "
 "Min.dauern."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Ich werde jetzt die Z Kalibrierung durchführen."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "SPANNRO. STARTP.FEH."
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "SPANNROL. SITZT FEST"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "INSPIZIERE FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "UNGÜLTIGER FIL.PLATZ"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -953,27 +954,27 @@ msgstr ""
 "stellungen unter Einstellungen - HW Setup - Stahlbleche."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Verbesserung des Bettkalibrierungs- punkts"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Infoanzeige"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Init. SD Karte"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Filament einlegen"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -982,282 +983,284 @@ msgstr ""
 "den Knopf."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
 "Interner Laufzeitfehler. MMU zurücksetzen oder Firmware aktualisieren."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Ist Filament geladen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Liegt Stahlblech auf dem Heizbett?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Wiederholung"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Letzter Druck"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Letzte Druckfehler"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Links"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Linker Lüfter?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Links [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Hell.wert"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Dimmwert"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Lineare Korrektur"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Z einstellen"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Alle laden"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Filament laden"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "In Düse laden"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Lade Filament Test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Lade Farbe"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Filament lädt"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Lose Riemenscheibe"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Laut"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW UPDATE NÖTIG"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware Fehler, setzen Sie die MMU zurück."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "MMU Mod."
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU REAGIERT NICHT"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU-Neuversuch: Stelle die Tempera- tur wieder her..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELBSTTEST FEHL."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "MMU Fehler"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "MMU Ladefehler"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr ""
 "MMU antwortet nicht korrekt. Überprüfen Sie die Verkabelung und die "
 "Anschlüsse."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr ""
 "MMU antwortet nicht. Überprüfen Sie die Verkabelung und die Anschlüsse."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU verbunden"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Magnet Komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Hauptmenü"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Schräglauf"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Messen der Referenzhöhe des Kalibrierpunktes"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Gitter"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "MeshBett Ausgleich"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Modus"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Moduswechsel erfolgt..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Weitere Details online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Bewege X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Bewege Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Bewege Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Achse bewegen"
 
@@ -1268,94 +1271,95 @@ msgid "Moving selector"
 msgstr "Bewege Selektor"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/V"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Neue Firmware- Version verfügbar:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Nein"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Keine SD Karte"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Keine Bewegung."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Ohne"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Nicht angeschlossen"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Dreht sich nicht"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Jetzt kalibriere ich den Abstand zwischen Düsenspitze und Druckbett."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jetzt werde ich die Düse für PLA vorheizen."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Testdruck jetzt vom Stahlblech entfernen."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Düse"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Düsenwechsel"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Düsen Dia."
 
@@ -1366,81 +1370,81 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Aus"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Alte Einstellungen gefunden. Standard PID, E-Steps u.s.w. werden gesetzt."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "An"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "Einmal"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSE THERM. FEHLER"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "PID Kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "PID Kalib. fertig"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "PID Kalibrierung"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "PINDA erwärmen"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "PINDA Kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "PINDA-Kalibrierung fehlgeschlagen"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1449,7 +1453,7 @@ msgstr ""
 "Menü Einstellungen -> PINDA kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "RIEHMENS. SITZT FEST"
 
@@ -1460,13 +1464,13 @@ msgid "Parking selector"
 msgstr "Parke Selektor"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Druck pausieren"
 
@@ -1477,7 +1481,7 @@ msgid "Performing cut"
 msgstr "Führe Schnitt aus"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1486,7 +1490,7 @@ msgstr ""
 "ersten 4 Punkte. Drucker sofort aus- schalten, wenn das Papier erfasst wird."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1495,28 +1499,28 @@ msgstr ""
 "dem Assistenten fort, indem Sie den Drucker neu starten."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "IR Sensor Verbindungen über- prüfen. Ist Filament entladen?"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Prüfen:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Reinigen Sie das Heizbett und drücken Sie dann den Knopf."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 "Entfernen Sie überstehendes Filament von der Düse. Klicken wenn sauber."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1524,7 +1528,7 @@ msgstr ""
 "laden."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1533,104 +1537,104 @@ msgstr ""
 "den Knopf, um es zu laden."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Laden Sie zuerst das Filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Spannrolle öffnen und Filament von Hand entfernen"
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Legen Sie das Stahlblech auf das Heizbett."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Drücken Sie den Knopf um das Filament zu entladen."
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Ziehen Sie das Filament sofort heraus"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Zuerst Transportsicherungen entfernen."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Entfernen Sie das Stahlblech vom Heizbett."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Zuerst XYZ Kalibrierung ausführen."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Entladen Sie erst das Filament und versuchen Sie es nochmal."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Bitte aktualisieren."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Warten"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Netzfehler"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Vorheizen"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Düse vorheizen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Vorheizen der Düse. Bitte warten."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Heizen zum Schnitt"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Heizen zum Auswurf"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Heizen zum Laden"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Heizen zum Entladen"
 
@@ -1641,48 +1645,48 @@ msgid "Preparing blade"
 msgstr "Bereite Messer vor"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Knopf drücken zum"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Drücken Sie den Knopf um die Düse vorzuheizen und fortzufahren."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Druck abgebrochen"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Drucklüfter:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Drucken von SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Druck pausiert"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Druckzeit"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Drucker IP Adr.:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1691,12 +1695,12 @@ msgstr ""
 "Schritte."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Düsendurchmesser weicht vom G-Code ab. Fortfahren?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1705,7 +1709,7 @@ msgstr ""
 "den Wert in den Einstellungen. Druck abgebrochen."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Der Riemenscheiben- motor ist blockiert. Sicherstellen, dass sich die "
@@ -1718,32 +1722,32 @@ msgid "Pushing filament"
 msgstr "Schiebe Filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "QUEUE VOLL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Hinten [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Druck wiederherstel."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Umbenennen"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1752,24 +1756,24 @@ msgstr ""
 "Prüfen Sie den G-Code auf Plätze außerhalb des Bereichs (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ Kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Druck fortsetzen"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Druck fortgesetzt"
 
@@ -1780,7 +1784,7 @@ msgid "Retract from FINDA"
 msgstr "Einziehen von FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Wdh."
 
@@ -1791,17 +1795,17 @@ msgid "Returning selector"
 msgstr "Selektor zurückfahr."
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Rechts"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Rechts [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1810,39 +1814,39 @@ msgstr ""
 "beginnen. Fortfahren?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "SD Karte"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELEK. STARTPOSFEHL."
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELEKTOR SITZT FEST"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "GESTOPPT."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Suche Bett Kalibrierpunkt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Auswahl"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1851,25 +1855,25 @@ msgstr ""
 " im On-Screen-Menü aus."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Wähle filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Wähle Sprache"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vorheiztemperatur auswählen, die Ihrem Material entspricht."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Wählen Sie die Temperatur, die zu Ihrem Material passt."
 
@@ -1880,72 +1884,72 @@ msgid "Selecting fil. slot"
 msgstr "Wähle Filament Platz"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Selbsttest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Selbsttest start"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Selbsttest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Selbsttest Fehler!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Selbsttest Error"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Selbsttest wird gestartet, um Startposition zu kalibrieren."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Sensor Info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "FSensor überprüft, entladen Sie jetzt das Filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Temp. einstellen:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Einstellungen"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Sehr schräg"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Stahlblech"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1958,23 +1962,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Endschalter Status"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Leise"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Leicht schräg"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1982,126 +1986,126 @@ msgstr ""
 "Einige Dateien wur- den nicht sortiert. Max. Dateien pro Verzeichnis = 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Fehler aufgetreten, Z-Kalibrierung erforderlich..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Sort."
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Sortiere Dateien"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Ton"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Tempo"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Dreht sich"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Stabile Umgebungs- temperatur 21-26C und feste Stand- fläche erforderlich."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statistiken"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Leise"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Stahlbleche"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Druck abbrechen"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Ausgetauscht"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "THERMISCHE ANOMALIE"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "TMC TREIBER FEHLER"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "TMC TREIBER RESET"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC KURZSCHLUSS"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC ÜBERHITZ.FEHL."
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNTERSPANN.FEHL."
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2110,27 +2114,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Thermomodell noch nicht kalibriert."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Temperaturen"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Teste filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2138,13 +2142,13 @@ msgstr ""
 "ob irgendetwas dessen Bewegung blockiert."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr "Selektor erreicht Startpos. nicht. Prüf, ob etwas blockiert."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2155,7 +2159,7 @@ msgstr ""
 "im Handbuch."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2164,63 +2168,63 @@ msgstr ""
 " Schritte."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Zeit"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Gesamt"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Gesamte Fehler"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Gesamtes Filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Gesamte Druckzeit"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Anpassen"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "ENTLADE MANUELL"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Entla."
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Fil. entladen"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Filament auswerfen"
 
@@ -2237,25 +2241,25 @@ msgid "Unloading to pulley"
 msgstr "Entlade zur Riemens."
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 "Überprüfung fehl- geschlagen, entladen Sie das Filament und nochmals "
 "versuchen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Spannungen"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "WARNUNG TMC ZU HEISS"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2268,209 +2272,203 @@ msgstr ""
 "Stealth Modus"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Warte auf Benutzer.."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Warte bis PINDA- Sonde abgekühlt ist"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Warte bis Heizung und Bett abgekühlt sind"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Warnen"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Warnung: Druckertyp und Platinentyp wurden beide geändert."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Warnung: Platinentyp wurde geändert."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Warnung: Druckertyp wurde geändert."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Konnten Sie das Filament entnehmen?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Verdrahtungsfehler"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Assistent"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "X-Korrektur"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "XYZ Kal. Details"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ Kalibrierung in Ordnung. Schräglauf wird automatisch korrigiert."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "XYZ Kalibrierung in Ordnung. X/Y Achsen sind etwas schräg. Gut gemacht!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "XYZ-Kalibrierung beeinträchtigt. Vordere Kal.-Punkte nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-Kalibrierung beeinträchtigt. Kal. -Punkt vorne rechts nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bett-Kalibrierpunkt nicht gefunden."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "XYZ-Kalibrierung fehlgeschlagen. Vordere Kal.-Punkte nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-Kalibrierung fehlgeschlagen - mehr im Handbuch."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "XYZ-Kalibrierung fehlgeschlagen. Kal. -Punkt vorne rechts nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 "XYZ-Kalibrierung ok. X/Y-Achsen sind senkrecht zueinander Glückwunsch!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Y Entfernung vom Min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Y-Korrektur"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Im Menü Kalibrierung -> Assistent können Sie den Assistenten immer neu "
 "starten."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Z-Korrektur"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Z-Test Nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] Punktversatz"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "und Knopf drücken"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "um Filament laden"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "um Filament entladen"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "unbekannt"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "Status unbekannt"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Aktualisiere"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "MMU Netzfehler"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Aus MMU auswerf."
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT AUSGEWORFEN"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2479,12 +2477,12 @@ msgstr ""
 "ist. Überprüfen Sie die Sensoren und die Verkabelung."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "FEHL LADEN ZUM EXTR:"
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2493,28 +2491,28 @@ msgstr ""
 " Verfeiner die Sensorkalibrierung, falls erforderlich."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU FEHLER"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Materialwechsel"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Entfernen Sie das ausgeworfene Filament von der Vorderseite der MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2523,63 +2521,55 @@ msgstr ""
 "dass sich kein Fil. im Selektor befindet und FINDA richtig funktioniert."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr "MMU FW ist inkompatibel mit Drucker FW. Update auf Version 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "In MMU laden"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "MK3-Firmware am MK3S-Drucker erkannt"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "MK3S-Firmware auf MK3-Drucker erkannt"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "UNBEKANNTER FEHLER"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Ein unerwarteter Fehler ist aufgetreten."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Auswerf."
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "FILAMENTWECHSEL"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Laden"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "M600 Filamentwechsel. Laden Sie ein neues Filament oder werfen Sie das alte "
 "aus."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Sensitivität"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "MeshBett Ausgleich fehlgeschlagen. Z Kalibrierung ausführen."
 
@@ -2594,9 +2584,18 @@ msgid "Set not Ready"
 msgstr "Nicht breit setzen"
 
 #. MSG_REPRINT c=7
-#: ../../Firmware/ultralcd.cpp:5189
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Abdruck"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Aktualisiere"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "MK3-Firmware am MK3S-Drucker erkannt"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "MK3S-Firmware auf MK3-Drucker erkannt"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Entferne das alte Fil. und drücke den Knopf, um das neue zu laden."

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2583,7 +2583,7 @@ msgstr "Bereit setzen"
 msgid "Set not Ready"
 msgstr "Nicht breit setzen"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Abdruck"

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 o mayor"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 o más nueva"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "%s nivel esperado"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Cancelar"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Ajustar-Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Todo bien"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Terminado. Felices impresiones!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Alfabeto"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Siemp."
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Ambiente"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "¿Carros Z izq./der. están arriba máximo?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Ir al origen"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Encendido"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "Carga auto. filam."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,108 +113,107 @@ msgid "Avoiding grind"
 msgstr "Evita morder"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Eje"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Longitud del eje"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Atrás"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Base"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Calentando Base"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Base preparada"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Corr. de la cama"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
 msgstr ""
-"Falló la nivelación. Sensor no funciona. ¿Restos en boquilla? Esperando "
-"reset."
+"Falló la nivelación. Sensor no funciona. ¿Restos en boquilla? Esperando reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Base/Calentador"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Estado de correa"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Test correa"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Se fue la luz. ¿Re- anudar la impresión?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Brill."
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Brillo"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "ERROR COMUNICACIÓN"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Calibrar XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Calibrar Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -224,13 +222,13 @@ msgstr ""
 "superiores. Después haz clic."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -239,156 +237,156 @@ msgstr ""
 "superiores. Después haz clic."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Calibrar pos.inicial"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Calibración"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Calibración OK"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "No se puede mover Selector o Tensor."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "No se puede realizar la acción, filamento ya cargado. Primero descarga."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "Tarjeta retirada"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Cambiar Tarj. SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Cambiar filamento"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Cambio correcto!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "¿Cambio correcto?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Control sensor X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Control sensor Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Control sensor Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Control base cal."
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Control endstops"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Verif. archivo"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Control fusor"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Comprobando sensores"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Comprobaciones"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "Borrar error TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Color no homogéneo"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Desde la comunidad"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Enfriar"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "¿Copiar idioma seleccionado?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Choque"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Det. choque"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Choque detectado."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -399,34 +397,34 @@ msgstr ""
 "en modo Normal."
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Cortar filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Cuchillo"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Fecha:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Oscuro"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Desact."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Apagar motores"
 
@@ -438,8 +436,8 @@ msgid "Disengaging idler"
 msgstr "Soltando tensor"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -449,21 +447,21 @@ msgstr ""
 "fijada. Siga el manual, capitulo Primeros Pasos."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 "¿Quieres repetir el último paso para re- ajustar la distancia boquilla-base?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Listo"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "Corregir-E"
 
@@ -492,13 +490,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Espera usuario"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "ERROR:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Expulsar de MMU"
 
@@ -510,17 +508,17 @@ msgid "Ejecting filament"
 msgstr "Expulsando filamento"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Fin de carrera"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Fin no alcanzado"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Finales de carrera"
 
@@ -532,45 +530,45 @@ msgid "Engaging idler"
 msgstr "Enganchando tensor"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Extrusor"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Info. del extrusor"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "Autocarg.fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "Det. atasco f"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "Fin fil."
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FIL. YA CARGADO"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NO SE ACTIVO"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -579,7 +577,7 @@ msgstr ""
 "manualmente. Com- prueba que el fil- amento puede moverse y FINDA funciona."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -588,65 +586,65 @@ msgstr ""
 "puede moverse y FINDA funciona."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA ATASCO FIL."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "FS acción"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR NO SE ACTIVO"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR MUY PRONTO"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR ATASCO FIL."
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "ERROR EJECUCIÓN FW"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Registro de fallos"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "Fallos totales MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Falsa activación"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Velocidad Vent"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Test ventiladores"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Comprob.vent"
 
@@ -675,46 +673,46 @@ msgid "Feeding to nozzle"
 msgstr "Aliment. a la boq."
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Fil. acabado"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Sensor Fil."
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filamento"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "¿Se extruye filamento y con el color correcto?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Fil. no introducido"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Sensor de fil."
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -723,7 +721,7 @@ msgstr ""
 "Asegúrate de que el filamento puede moverse y el sensor funciona."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -732,7 +730,7 @@ msgstr ""
 " el filamento llegó al sensor y que éste funciona."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -742,42 +740,42 @@ msgstr ""
 " ok."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Filamento usado"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "¿Archivo incompleto. Continuar de todos modos?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Term. movimientos"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Cal. primera cap."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Primero, hare el Selftest para comprobar los problemas de montaje más "
 "comunes."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Flujo"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -786,58 +784,58 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "¿Vent. frontal?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Frontal [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Vents. front/izqui."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "Código G laminado para un nivel dif. ¿Continuar?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
 msgstr ""
-"Código G laminado para un nivel diferente. Vuelve a laminar el modelo de "
-"nuevo. Impresión cancelada."
+"Código G laminado para un nivel diferente. Vuelve a laminar el modelo de nuevo. "
+"Impresión cancelada."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "Código G laminado para un tipo de impresora dif.Cont.?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
 msgstr ""
-"Código G laminado para una impresora diferente. Vuelve a laminar el modelo "
-"de nuevo. Impresión cancelada."
+"Código G laminado para una impresora diferente. Vuelve a laminar el modelo de nuevo."
+" Impresión cancelada."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "Código G laminado para nuevo firmware. ¿Continuar?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -846,35 +844,35 @@ msgstr ""
 "cancelada."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "Configuración HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Calentador/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Calentando..."
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Calentadores desactivados por el temporizador de seguridad."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Calentando acabado."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -885,17 +883,17 @@ msgstr ""
 "listo para imprimir."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
 msgstr ""
-"Hola, soy tu impresora Original Prusa i3. ¿Quieres que te guíe a traves de "
-"la configuración?"
+"Hola, soy tu impresora Original Prusa i3. ¿Quieres que te guíe a traves de la "
+"configuración?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Rend.pleno"
 
@@ -906,48 +904,48 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Fusor a 280C! ¿Boquilla cambiado y ajust. a la medida?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Vent. d. fusor:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Haré la calibración XYZ. Puede tardar hasta 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Voy a hacer Calibración Z ahora."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "TENSOR: ERROR HOME"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "TENSOR: ERROR MOV."
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "INSPECCIONAR FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "HERR. INVALIDA"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -956,27 +954,27 @@ msgstr ""
 "Ajustes HW - Planchas acero."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Mejorando punto calibración base"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Monitorizar"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Init. Tarjeta SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Introducir filamento"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -984,280 +982,279 @@ msgstr ""
 "Inserta el filamento (no lo cargue) en el extrusor y luego presiona el dial."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
-msgstr "Error interno de ejecución. Reinicia la MMU o actualiza el firmware."
+msgstr ""
+"Error interno de ejecución. Reinicia la MMU o actualiza el firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "¿Esta el filamento cargado?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "¿Está la lámina sobre la base?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Iteración"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Ultima impresión"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Últimos imp. fallos"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Izquierda"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "¿Vent. izquierdo?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Izquierda [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Valor brill."
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Valor oscuro"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Correc. Linealidad"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Ajuste en vivo Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Intr. todos fil."
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Introducir fil."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Cargar a boquilla"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Prueba de carga"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Cambiando color"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Introduciendo filam."
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Polea suelta"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Alto"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "ACT. FW MMU PRECISA"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Error interno del firmware MMU, reinicia el MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "Modo MMU"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NO RESPONDE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Reintento: Restaurando temperatura..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST FALLO"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "Fallos MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "Carga MMU falla"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU no responde correctamente. Revisa los cables y conectores."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "La MMU no responde. Revisa los cables y conectores."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU conectado"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Comp. imanes"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Menu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Desv. medida"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Midiendo altura del punto de calibración"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Malla"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Nivela. Malla Base"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Modo"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Cambio de modo progresando ..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Modelo"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Más detalles online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Mover X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Mover Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Mover Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Mover ejes"
 
@@ -1268,63 +1265,62 @@ msgid "Moving selector"
 msgstr "Moviendo selector"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Nuevo firmware disponible:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "No"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "No hay tarjeta SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Sin movimiento"
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Ninguno"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "No hay conexión"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Ventilador no gira"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1332,33 +1328,33 @@ msgstr ""
 " la base."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Ahora precalentaré la boquilla para PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Ahora retira la prueba de la lámina de acero."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Boquilla"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Cambio de boquilla"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "D boquilla"
 
@@ -1369,82 +1365,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Ina"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Se han encontrado ajustes anteriores. Se ajustara el PID, los pasos del "
 "extrusor, etc."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "Act"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "Una vez"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSA ERROR TÉRMICO"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "Cal. PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "Cal. PID terminada"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "Calibración PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "Calentando PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "Cal. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "Fallo de la calibración de PINDA"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1453,7 +1449,7 @@ msgstr ""
 "menu Configuración -> Cal. PINDA"
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "POLEA: ERROR MOV."
 
@@ -1464,13 +1460,13 @@ msgid "Parking selector"
 msgstr "Aparcando selector"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pausa"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Pausar impresión"
 
@@ -1481,7 +1477,7 @@ msgid "Performing cut"
 msgstr "Realizando corte"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1490,7 +1486,7 @@ msgstr ""
 "los primeros 4 puntos. Si la boquilla coge el papel, apague inmediatamente."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1499,140 +1495,140 @@ msgstr ""
 "continua con el Asistente."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Comprueba la conexión del IR sensor y filamento está descargado."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Controla:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Limpia la superficie de la base, y luego presiona el dial."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Limpia boquilla para calibración. Clic cuando acabes."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Coloca el filamento en el extrusor, luego presiona el dial para cargarlo."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
 msgstr ""
-"Coloca el filamento en el primer tubo de la MMU, luego presiona el dial para"
-" cargarlo."
+"Coloca el filamento en el primer tubo de la MMU, luego presiona el dial "
+"para cargarlo."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Carga primero el filamento."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Abre el tensor y retira el filamento manualmente."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Coloca la lam. de acero en la base."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Pulsa el dial para descargar el filamento"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Retira el filamento de inmediato"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Retira los soportes de envío primero."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Retira la lam. de acero de la base."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Realiza la calibración XYZ primero."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Primero descarga el filamento, luego repite esta acción."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Actualiza por favor."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Por favor espera"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Fallos energía"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Precalentar"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Precalentar boquilla"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Precalent. boquilla. Espera por favor."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Precalent. cortar"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Precalent. expulsar"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Precalent. cargar"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Precalent. descargar"
 
@@ -1643,48 +1639,48 @@ msgid "Preparing blade"
 msgstr "Preparando cuchilla"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Pulsa el dial"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pulsa el dial para precalentar la boquilla y continue."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Impresión cancelada"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Vent.fusor:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Menu tarjeta SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Impresión en pausa"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Tiempo de imp."
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Dir. IP impresora:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1693,12 +1689,12 @@ msgstr ""
 "Calibración flujo."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diámetro boquilla impresora difiere de cod.G. ¿Continuar?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1707,7 +1703,7 @@ msgstr ""
 "ajustes. Impresión cancelada."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "El motor de la polea se ha parado. Asegúrate de que la polea puede moverse y"
@@ -1720,32 +1716,32 @@ msgid "Pushing filament"
 msgstr "Empujando filamento"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "COLA LLENA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "Puerto RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Trasera [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Recuper. impresión"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Renombrar"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1754,24 +1750,24 @@ msgstr ""
 "para si el índice de herramienta está fuera de rango (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Reset calibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Reanudar impres."
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Continuan. impresión"
 
@@ -1782,7 +1778,7 @@ msgid "Retract from FINDA"
 msgstr "Retraer del FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Reint."
 
@@ -1793,17 +1789,17 @@ msgid "Returning selector"
 msgstr "Selector volviendo"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Derecha"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Derecha [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1812,39 +1808,39 @@ msgstr ""
 "comenzará de nuevo. ¿Continuar?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "Tarj. SD"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELECT. SIN HOME"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECT. SIN MOVERSE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "PARADA"
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Buscando punto de calibración base"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Seleccionar"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1853,27 +1849,27 @@ msgstr ""
 " el menu en pantalla."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Selecciona filam.:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Cambiar el idioma"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selecciona la temperatura para precalentar la boquilla que se ajuste a tu "
 "material."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Selecciona la temperatura adecuada a tu material."
 
@@ -1884,74 +1880,74 @@ msgid "Selecting fil. slot"
 msgstr "Eligiendo hueco fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Iniciar Selftest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Error Selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Fallo Selftest"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
-"Se realizará el selftest para calibrar con precision la vuelta a la posición"
-" inicial sin sensores."
+"Se realizará el selftest para calibrar con precision la vuelta a la "
+"posición inicial sin sensores."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Info sensor"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verificado, retira el filamento ahora."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Establecer temp.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Configuración"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Desv. severa"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Lámina"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1964,23 +1960,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Mostrar endstops"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Acallar"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Desv. ligera"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1989,126 +1985,126 @@ msgstr ""
 "ordenar."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problema encontrado, nivelación Z forzosa ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Ordenar"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Ordenando archivos"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Sonido"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Velocidad"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Ventilador girando"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Se necesita una temperatura ambiente ente 21 y 26C y un soporte rígido."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Estadísticas"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Sigilo"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Lámina de acero"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Parar"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Detener impresión"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Estricto"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Soporte"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Intercambiado"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALÍA TÉRMICA"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "ERROR DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "RESET DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "CORTO DRIVER TMC"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "ERROR SOBRECAL TMC"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERROR SBRVOLTAJE TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2117,27 +2113,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Modelo térmico todavía sin cal."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Temperaturas"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Probando filamento"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2145,7 +2141,7 @@ msgstr ""
 "movimiento."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2153,7 +2149,7 @@ msgstr ""
 "su movimiento."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2164,7 +2160,7 @@ msgstr ""
 "de calibración)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2173,63 +2169,63 @@ msgstr ""
 "Primeros pasos."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Tiempo"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Expirar"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Fallos totales"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Filamento total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Tiempo total imp."
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Ajustar"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "DESCARGA MANUAL"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Desc."
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Descarga fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Descargando fil."
 
@@ -2246,23 +2242,23 @@ msgid "Unloading to pulley"
 msgstr "Descarg. hasta polea"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "La verificación falló, retira el filamento e intenta nuevamente."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Voltajes"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "AVISO TMC DEM. CALOR"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2275,193 +2271,199 @@ msgstr ""
 "Modo silencio"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Esperando ordenes..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Esperando a que se enfríe la sonda PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Esperando enfriamiento de la base y boquilla."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Aviso"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr ""
 "Aviso: tanto el tipo de impresora como el tipo de la placa han cambiado."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Aviso: el tipo de placa ha cambiado."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Aviso: ha cambiado el tipo de impresora."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "¿Se descargó con éxito el filamento?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Error de conexión"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Asistente"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "Corregir-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "Detalles cal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibración XYZ correcta. La desviación se corregirá automáticamente."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibración XYZ correcta. Los ejes X/Y están ligeramente desviados. Buen "
 "trabajo!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibración XYZ comprometida. Puntos frontales no alcanzables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Calibración XYZ comprometida. Punto frontal derecho no alcanzable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibración XYZ fallida. Puntos de calibración en la base no encontrados."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibración XYZ fallida. Puntos frontales no alcanzables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibración XYZ fallida. Consulta el manual."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibración XYZ fallad. Punto frontal derecho no alcanzable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibración XYZ ok. Ejes X/Y perpendiculares. Enhorabuena!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Dist. en Y desde min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Corregir-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Si"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Siempre puedes acceder al asistente desde Calibración -> Asistente"
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Corregir-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Z-sensor nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "y presiona el dial"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "para cargar el fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "para descargar fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "desconocido"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "estado desconocido"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Actualizar"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "Fallo red MMU"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENTO EXPULSADO"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2470,12 +2472,12 @@ msgstr ""
 "filamento cargado. Comprueba los sensores y el cableado."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "FALL. CARGAR A EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2484,28 +2486,28 @@ msgstr ""
 "filamento. Refina la calibración del sensor, si es necesario."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU ERROR"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Cambios materiales"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Retire el filamento expulsado de la parte frontal de la MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2515,7 +2517,7 @@ msgstr ""
 "correctamente."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2523,48 +2525,56 @@ msgstr ""
 "Actualizar a la versión 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Precarga a MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "Firmware MK3 detectado en impresora MK3S"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "Firmware MK3S detectado en impresora MK3"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "ERROR DESCONOCIDO"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Ocurrió un error inesperado."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Expulsar"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "CAMBIO DE FILAMENTO"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Cargar"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "Cambio de filamento M600. Cargue un filamento nuevo o expulse el anterior."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Sensibilidad"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Nivelación fallida. Ejecute la calibración Z."
 
@@ -2581,16 +2591,7 @@ msgstr "Conjunto no listo"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Reimprimir"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Actualizar"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "Firmware MK3 detectado en impresora MK3S"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "Firmware MK3S detectado en impresora MK3"
+msgstr "Volver a imprimir"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2578,7 +2578,7 @@ msgstr "Listo"
 msgid "Set not Ready"
 msgstr "Conjunto no listo"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Reimprimir"

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2588,6 +2588,11 @@ msgstr "Listo"
 msgid "Set not Ready"
 msgstr "Conjunto no listo"
 
+#. MSG_REPRINT c=10
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Reimprimir"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Retira el fil. viejo y presiona el dial para comenzar a cargar el nuevo."

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 o mayor"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 o más nueva"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "%s nivel esperado"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Cancelar"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Ajustar-Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Todo bien"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Terminado. Felices impresiones!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Alfabeto"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Siemp."
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Ambiente"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "¿Carros Z izq./der. están arriba máximo?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Ir al origen"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Encendido"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "Carga auto. filam."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Evita morder"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Eje"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Longitud del eje"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Atrás"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Base"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Calentando Base"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Base preparada"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Corr. de la cama"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +168,54 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Base/Calentador"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Estado de correa"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Test correa"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Se fue la luz. ¿Re- anudar la impresión?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Brill."
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Brillo"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "ERROR COMUNICACIÓN"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Calibrar XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Calibrar Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +224,13 @@ msgstr ""
 "superiores. Después haz clic."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,156 +239,156 @@ msgstr ""
 "superiores. Después haz clic."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Calibrar pos.inicial"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Calibración"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Calibración OK"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "No se puede mover Selector o Tensor."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "No se puede realizar la acción, filamento ya cargado. Primero descarga."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "Tarjeta retirada"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Cambiar Tarj. SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Cambiar filamento"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Cambio correcto!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "¿Cambio correcto?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Control sensor X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Control sensor Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Control sensor Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Control base cal."
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Control endstops"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Verif. archivo"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Control fusor"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Comprobando sensores"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Comprobaciones"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "Borrar error TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Color no homogéneo"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Desde la comunidad"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Enfriar"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "¿Copiar idioma seleccionado?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Choque"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Det. choque"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Choque detectado."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -398,34 +399,34 @@ msgstr ""
 "en modo Normal."
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Cortar filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Cuchillo"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Fecha:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Oscuro"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Desact."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Apagar motores"
 
@@ -437,8 +438,8 @@ msgid "Disengaging idler"
 msgstr "Soltando tensor"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -448,21 +449,21 @@ msgstr ""
 "fijada. Siga el manual, capitulo Primeros Pasos."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 "¿Quieres repetir el último paso para re- ajustar la distancia boquilla-base?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Listo"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "Corregir-E"
 
@@ -491,13 +492,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Espera usuario"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "ERROR:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Expulsar de MMU"
 
@@ -509,17 +510,17 @@ msgid "Ejecting filament"
 msgstr "Expulsando filamento"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Fin de carrera"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Fin no alcanzado"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Finales de carrera"
 
@@ -531,45 +532,45 @@ msgid "Engaging idler"
 msgstr "Enganchando tensor"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Extrusor"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Info. del extrusor"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "Autocarg.fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "Det. atasco f"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "Fin fil."
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FIL. YA CARGADO"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NO SE ACTIVO"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -578,7 +579,7 @@ msgstr ""
 "manualmente. Com- prueba que el fil- amento puede moverse y FINDA funciona."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -587,65 +588,65 @@ msgstr ""
 "puede moverse y FINDA funciona."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA ATASCO FIL."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "FS acción"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR NO SE ACTIVO"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR MUY PRONTO"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR ATASCO FIL."
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "ERROR EJECUCIÓN FW"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Registro de fallos"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "Fallos totales MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Falsa activación"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Velocidad Vent"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Test ventiladores"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Comprob.vent"
 
@@ -674,46 +675,46 @@ msgid "Feeding to nozzle"
 msgstr "Aliment. a la boq."
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Fil. acabado"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Sensor Fil."
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filamento"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "¿Se extruye filamento y con el color correcto?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Fil. no introducido"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Sensor de fil."
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -722,7 +723,7 @@ msgstr ""
 "Asegúrate de que el filamento puede moverse y el sensor funciona."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -731,7 +732,7 @@ msgstr ""
 " el filamento llegó al sensor y que éste funciona."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -741,42 +742,42 @@ msgstr ""
 " ok."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Filamento usado"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "¿Archivo incompleto. Continuar de todos modos?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Term. movimientos"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Cal. primera cap."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Primero, hare el Selftest para comprobar los problemas de montaje más "
 "comunes."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Flujo"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -785,28 +786,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "¿Vent. frontal?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Frontal [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Vents. front/izqui."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "Código G laminado para un nivel dif. ¿Continuar?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -815,14 +816,14 @@ msgstr ""
 "nuevo. Impresión cancelada."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "Código G laminado para un tipo de impresora dif.Cont.?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -831,12 +832,12 @@ msgstr ""
 "de nuevo. Impresión cancelada."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "Código G laminado para nuevo firmware. ¿Continuar?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -845,35 +846,35 @@ msgstr ""
 "cancelada."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "Configuración HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Calentador/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Calentando..."
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Calentadores desactivados por el temporizador de seguridad."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Calentando acabado."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -884,7 +885,7 @@ msgstr ""
 "listo para imprimir."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -893,8 +894,8 @@ msgstr ""
 "la configuración?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Rend.pleno"
 
@@ -905,48 +906,48 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Fusor a 280C! ¿Boquilla cambiado y ajust. a la medida?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Vent. d. fusor:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Haré la calibración XYZ. Puede tardar hasta 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Voy a hacer Calibración Z ahora."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "TENSOR: ERROR HOME"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "TENSOR: ERROR MOV."
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "INSPECCIONAR FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "HERR. INVALIDA"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -955,27 +956,27 @@ msgstr ""
 "Ajustes HW - Planchas acero."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Mejorando punto calibración base"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Monitorizar"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Init. Tarjeta SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Introducir filamento"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -983,278 +984,280 @@ msgstr ""
 "Inserta el filamento (no lo cargue) en el extrusor y luego presiona el dial."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Error interno de ejecución. Reinicia la MMU o actualiza el firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "¿Esta el filamento cargado?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "¿Está la lámina sobre la base?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteración"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Ultima impresión"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Últimos imp. fallos"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Izquierda"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "¿Vent. izquierdo?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Izquierda [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Valor brill."
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Valor oscuro"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Correc. Linealidad"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Ajuste en vivo Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Intr. todos fil."
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Introducir fil."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Cargar a boquilla"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Prueba de carga"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Cambiando color"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Introduciendo filam."
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Polea suelta"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Alto"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "ACT. FW MMU PRECISA"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Error interno del firmware MMU, reinicia el MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "Modo MMU"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NO RESPONDE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Reintento: Restaurando temperatura..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST FALLO"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "Fallos MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "Carga MMU falla"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU no responde correctamente. Revisa los cables y conectores."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "La MMU no responde. Revisa los cables y conectores."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU conectado"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Comp. imanes"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Menu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Desv. medida"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Midiendo altura del punto de calibración"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Malla"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Nivela. Malla Base"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Modo"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Cambio de modo progresando ..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Modelo"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Más detalles online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Mover X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Mover Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Mover Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Mover ejes"
 
@@ -1265,62 +1268,63 @@ msgid "Moving selector"
 msgstr "Moviendo selector"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Nuevo firmware disponible:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "No"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "No hay tarjeta SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Sin movimiento"
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Ninguno"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "No hay conexión"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Ventilador no gira"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1328,33 +1332,33 @@ msgstr ""
 " la base."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Ahora precalentaré la boquilla para PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Ahora retira la prueba de la lámina de acero."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Boquilla"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Cambio de boquilla"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "D boquilla"
 
@@ -1365,82 +1369,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Ina"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Se han encontrado ajustes anteriores. Se ajustara el PID, los pasos del "
 "extrusor, etc."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "Act"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "Una vez"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSA ERROR TÉRMICO"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "Cal. PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "Cal. PID terminada"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "Calibración PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "Calentando PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "Cal. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "Fallo de la calibración de PINDA"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1449,7 +1453,7 @@ msgstr ""
 "menu Configuración -> Cal. PINDA"
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "POLEA: ERROR MOV."
 
@@ -1460,13 +1464,13 @@ msgid "Parking selector"
 msgstr "Aparcando selector"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pausa"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Pausar impresión"
 
@@ -1477,7 +1481,7 @@ msgid "Performing cut"
 msgstr "Realizando corte"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1486,7 +1490,7 @@ msgstr ""
 "los primeros 4 puntos. Si la boquilla coge el papel, apague inmediatamente."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1495,34 +1499,34 @@ msgstr ""
 "continua con el Asistente."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Comprueba la conexión del IR sensor y filamento está descargado."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Controla:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Limpia la superficie de la base, y luego presiona el dial."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Limpia boquilla para calibración. Clic cuando acabes."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Coloca el filamento en el extrusor, luego presiona el dial para cargarlo."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1531,104 +1535,104 @@ msgstr ""
 " cargarlo."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Carga primero el filamento."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Abre el tensor y retira el filamento manualmente."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Coloca la lam. de acero en la base."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Pulsa el dial para descargar el filamento"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Retira el filamento de inmediato"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Retira los soportes de envío primero."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Retira la lam. de acero de la base."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Realiza la calibración XYZ primero."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Primero descarga el filamento, luego repite esta acción."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Actualiza por favor."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Por favor espera"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Fallos energía"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Precalentar"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Precalentar boquilla"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Precalent. boquilla. Espera por favor."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Precalent. cortar"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Precalent. expulsar"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Precalent. cargar"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Precalent. descargar"
 
@@ -1639,48 +1643,48 @@ msgid "Preparing blade"
 msgstr "Preparando cuchilla"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Pulsa el dial"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pulsa el dial para precalentar la boquilla y continue."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Impresión cancelada"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Vent.fusor:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Menu tarjeta SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Impresión en pausa"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Tiempo de imp."
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Dir. IP impresora:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1689,12 +1693,12 @@ msgstr ""
 "Calibración flujo."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diámetro boquilla impresora difiere de cod.G. ¿Continuar?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1703,7 +1707,7 @@ msgstr ""
 "ajustes. Impresión cancelada."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "El motor de la polea se ha parado. Asegúrate de que la polea puede moverse y"
@@ -1716,32 +1720,32 @@ msgid "Pushing filament"
 msgstr "Empujando filamento"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "COLA LLENA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "Puerto RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Trasera [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Recuper. impresión"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Renombrar"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1750,24 +1754,24 @@ msgstr ""
 "para si el índice de herramienta está fuera de rango (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Reset calibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Reanudar impres."
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Continuan. impresión"
 
@@ -1778,7 +1782,7 @@ msgid "Retract from FINDA"
 msgstr "Retraer del FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Reint."
 
@@ -1789,17 +1793,17 @@ msgid "Returning selector"
 msgstr "Selector volviendo"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Derecha"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Derecha [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1808,39 +1812,39 @@ msgstr ""
 "comenzará de nuevo. ¿Continuar?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "Tarj. SD"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELECT. SIN HOME"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECT. SIN MOVERSE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "PARADA"
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Buscando punto de calibración base"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Seleccionar"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1849,27 +1853,27 @@ msgstr ""
 " el menu en pantalla."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Selecciona filam.:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Cambiar el idioma"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selecciona la temperatura para precalentar la boquilla que se ajuste a tu "
 "material."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Selecciona la temperatura adecuada a tu material."
 
@@ -1880,74 +1884,74 @@ msgid "Selecting fil. slot"
 msgstr "Eligiendo hueco fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Iniciar Selftest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Error Selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Fallo Selftest"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Se realizará el selftest para calibrar con precision la vuelta a la posición"
 " inicial sin sensores."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Info sensor"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verificado, retira el filamento ahora."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Establecer temp.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Configuración"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Desv. severa"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Lámina"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1960,23 +1964,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Mostrar endstops"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Acallar"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Desv. ligera"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1985,126 +1989,126 @@ msgstr ""
 "ordenar."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problema encontrado, nivelación Z forzosa ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Ordenar"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Ordenando archivos"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Sonido"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Velocidad"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Ventilador girando"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Se necesita una temperatura ambiente ente 21 y 26C y un soporte rígido."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Estadísticas"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Sigilo"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Lámina de acero"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Parar"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Detener impresión"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Estricto"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Soporte"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Intercambiado"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALÍA TÉRMICA"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "ERROR DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "RESET DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "CORTO DRIVER TMC"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "ERROR SOBRECAL TMC"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERROR SBRVOLTAJE TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2113,27 +2117,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Modelo térmico todavía sin cal."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Temperaturas"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Probando filamento"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2141,7 +2145,7 @@ msgstr ""
 "movimiento."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2149,7 +2153,7 @@ msgstr ""
 "su movimiento."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2160,7 +2164,7 @@ msgstr ""
 "de calibración)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2169,63 +2173,63 @@ msgstr ""
 "Primeros pasos."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Tiempo"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Expirar"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Fallos totales"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Filamento total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Tiempo total imp."
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Ajustar"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "DESCARGA MANUAL"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Desc."
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Descarga fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Descargando fil."
 
@@ -2242,23 +2246,23 @@ msgid "Unloading to pulley"
 msgstr "Descarg. hasta polea"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "La verificación falló, retira el filamento e intenta nuevamente."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Voltajes"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "AVISO TMC DEM. CALOR"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2271,199 +2275,193 @@ msgstr ""
 "Modo silencio"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Esperando ordenes..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Esperando a que se enfríe la sonda PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Esperando enfriamiento de la base y boquilla."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Aviso"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr ""
 "Aviso: tanto el tipo de impresora como el tipo de la placa han cambiado."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Aviso: el tipo de placa ha cambiado."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Aviso: ha cambiado el tipo de impresora."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "¿Se descargó con éxito el filamento?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Error de conexión"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Asistente"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "Corregir-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "Detalles cal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibración XYZ correcta. La desviación se corregirá automáticamente."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibración XYZ correcta. Los ejes X/Y están ligeramente desviados. Buen "
 "trabajo!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibración XYZ comprometida. Puntos frontales no alcanzables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Calibración XYZ comprometida. Punto frontal derecho no alcanzable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibración XYZ fallida. Puntos de calibración en la base no encontrados."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibración XYZ fallida. Puntos frontales no alcanzables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibración XYZ fallida. Consulta el manual."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibración XYZ fallad. Punto frontal derecho no alcanzable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibración XYZ ok. Ejes X/Y perpendiculares. Enhorabuena!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Dist. en Y desde min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Corregir-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Si"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Siempre puedes acceder al asistente desde Calibración -> Asistente"
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Corregir-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Z-sensor nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "y presiona el dial"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "para cargar el fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "para descargar fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "desconocido"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "estado desconocido"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Actualizar"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "Fallo red MMU"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENTO EXPULSADO"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2472,12 +2470,12 @@ msgstr ""
 "filamento cargado. Comprueba los sensores y el cableado."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "FALL. CARGAR A EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2486,28 +2484,28 @@ msgstr ""
 "filamento. Refina la calibración del sensor, si es necesario."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU ERROR"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Cambios materiales"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Retire el filamento expulsado de la parte frontal de la MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2517,7 +2515,7 @@ msgstr ""
 "correctamente."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2525,56 +2523,48 @@ msgstr ""
 "Actualizar a la versión 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Precarga a MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "Firmware MK3 detectado en impresora MK3S"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "Firmware MK3S detectado en impresora MK3"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "ERROR DESCONOCIDO"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Ocurrió un error inesperado."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Expulsar"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "CAMBIO DE FILAMENTO"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Cargar"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "Cambio de filamento M600. Cargue un filamento nuevo o expulse el anterior."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Sensibilidad"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Nivelación fallida. Ejecute la calibración Z."
 
@@ -2588,10 +2578,19 @@ msgstr "Listo"
 msgid "Set not Ready"
 msgstr "Conjunto no listo"
 
-#. MSG_REPRINT c=10
-#: ../../Firmware/ultralcd.cpp:5189
+#. MSG_REPRINT c=7
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Reimprimir"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Actualizar"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "Firmware MK3 detectado en impresora MK3S"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "Firmware MK3S detectado en impresora MK3"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2600,6 +2600,11 @@ msgstr "Ensemble prête"
 msgid "Set not Ready"
 msgstr "Ensemble pas prête"
 
+#. MSG_REPRINT c=13
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Réimpresision"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Retirez l'ancien fil. puis appuyez sur le bouton pour charger le nouveau."

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 ou +ancien"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 ou +recent"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "niveau %s attendu"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Annuler"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Ajuster Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Tout est correct"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Tout est pret. Bonne impression!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Alphabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Tjrs"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Ambiant"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "Z-carriages gauche + droite tout en haut?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Assist"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Mise a 0 des axes"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Puiss.auto"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "Autocharge du fil."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,52 +113,52 @@ msgid "Avoiding grind"
 msgstr "Éviter broiement"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Axe"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Longueur de l'axe"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Retour"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Lit"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Chauffe du lit"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Lit termine"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Réglage lit"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -168,54 +167,54 @@ msgstr ""
 "attente d'un reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Lit/Chauffage"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Statut courroie"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Test de courroie"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Coupure détectée. Reprendre impres.?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Brill."
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Luminosité"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "ERREUR COMMUNICATION"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Calibrer XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Calibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -224,13 +223,13 @@ msgstr ""
 "l'axe Z jusqu'aux butées. Cliquez une fois fait."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Calibration Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -239,28 +238,28 @@ msgstr ""
 " Z jusqu'aux butées. Cliquez une fois fait."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Calib. mise a 0"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Calibration"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Calibration terminée"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Impossible de déplacer le Sélecteur ou l'Idler."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
@@ -268,128 +267,128 @@ msgstr ""
 "d'abord."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "Carte retiree"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Changez carte SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Changer filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Changement réussi!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Change correctement?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Vérifier axe X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Vérifier axe Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Vérifier axe Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Vérifier lit"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Vérifier butées"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Vérifier fichier"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Vérifier du hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Vérifier capteurs"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Verifications"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "Effacer l'error TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Couleur incorrecte"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Fait de community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Refroidissement"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Copier la langue choisie?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Crash détecté"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Crash détecté."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -401,34 +400,34 @@ msgstr ""
 "mode Normal"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Coupe filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Coupeur"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Date:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Sombre"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Désact."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Désactiver moteurs"
 
@@ -440,18 +439,18 @@ msgid "Disengaging idler"
 msgstr "Désenga.t de l'idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
 "calibration."
 msgstr ""
-"La distance entre de la buse et du lit n'a pas encore été réglée. Suivez le "
-"manuel, chap. Premiers pas."
+"La distance entre de la buse et du lit n'a pas encore été réglée. Suivez"
+" le manuel, chap. Premiers pas."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -459,14 +458,14 @@ msgstr ""
 "Voulez-vous refaire l'étape pour réajuster la hauteur entre la buse et le "
 "lit?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Fait"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "Correct-E"
 
@@ -495,13 +494,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Att. Utilisateur"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "ERREUR:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Éjecter du MMU"
 
@@ -513,17 +512,17 @@ msgid "Ejecting filament"
 msgstr "Le fil. remonte"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Butée"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Butée non atteinte"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Butées"
 
@@ -535,55 +534,55 @@ msgid "Engaging idler"
 msgstr "Engagem.t de l'idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Extrudeur"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Infos extrudeur"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "F. autocharg."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "Detect bour F"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "Fin de F."
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT DEJA CHARGE"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NON DÉCLENCHÉE"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
 msgstr ""
-"FINDA non désactivé lors du déchargement du filament. Essayez de décharger à"
-" la main. Assurez-vous que le filament peut bouger et que la FINDA "
+"FINDA non désactivé lors du déchargement du filament. Essayez de décharger "
+"à la main. Assurez-vous que le filament peut bouger et que la FINDA "
 "fonctionne."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -592,65 +591,65 @@ msgstr ""
 "vous que le filament peut bouger et que la FINDA fonctionne."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. BLOQUE"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "Action FS"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "CAPTEUR F. NON DECL."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "CAPTEUR F TROP TOT"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "CAPTEUR F: F. BLOQUE"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "ERREUR EXÉCUTION FW"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Stat. d'échec"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "Stat. d'échec MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Faux déclenchement"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Vitesse vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Test du ventilateur"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Vérif. vent."
 
@@ -679,46 +678,46 @@ msgid "Feeding to nozzle"
 msgstr "Chargement vers buse"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Fins filament"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Capteur Fil."
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrude et avec bonne couleur?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Filament non charge"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Capteur Fil."
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -727,7 +726,7 @@ msgstr ""
 "que le filament peut bouger et que le capteur fonctionne."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -736,7 +735,7 @@ msgstr ""
 " le filament a atteint le capteur f et que le capteur fonctionne."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -745,42 +744,42 @@ msgstr ""
 "Vérifiez le tube PTFE. Vérifiez que le capteur fonctionne."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Filament utilise"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "Fichier incomplet. Continuer qd meme?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Mouvement final"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Cal. 1ere couche"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
-"Je vais lancer le selftest pour verifier les problèmes d'assemblage les plus"
-" communs."
+"Je vais lancer le selftest pour verifier les problèmes d'assemblage les "
+"plus communs."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Flux"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -789,44 +788,44 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Ventilo impr avant?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Avant [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Ventilos avt/gauche"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code a été préparé pour un niveau diff. Continuer?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
 msgstr ""
-"G-code a été préparé pour un niveau différent. Découpez le modèle à nouveau."
-" Impression annulée."
+"G-code a été préparé pour un niveau différent. Découpez le modèle à nouveau. "
+"Impression annulée."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code pour un type d'imprimante différent. Continue?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -835,12 +834,12 @@ msgstr ""
 "Impression annulée."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code a été préparé pour un FW plus récent. Cont.?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -849,35 +848,35 @@ msgstr ""
 "annulée."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "Config HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Chauffage/Thermistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Chauffe"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Chauffage désactivé par le compteur de sécurité."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Chauffe terminée."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -888,17 +887,17 @@ msgstr ""
 "à imprimer."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
 msgstr ""
-"Je suis votre imprimante Original Prusa i3. Voulez-vous que je vous guide à "
-"travers le processus d'installation"
+"Je suis votre imprimante Original Prusa i3. Voulez-vous que je vous "
+"guide à travers le processus d'installation?
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Haut.puiss"
 
@@ -909,50 +908,50 @@ msgid "Homing"
 msgstr "Mise à zéro"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend à 280C! Buse changée et resserrée aux spécifications?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Vent. hotend:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr ""
 "Je vais maintenant lancer la calibration XYZ. Cela peut prendre jusqu'à 24 "
 "min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Je vais maintenant lancer la calibration Z."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "RAZ IDLER IMPOSSIBLE"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "ÉCHEC MOUV.T IDLER"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "VÉRIFIEZ FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "OUTIL INVALIDE"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -961,27 +960,27 @@ msgstr ""
 "Réglages - Config HW - Plaque en acier."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Amelioration du point de calibration du lit"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Écran d'info"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Init. carte SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Insérez le filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -990,7 +989,7 @@ msgstr ""
 "appuyez sur le bouton."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
@@ -998,275 +997,273 @@ msgstr ""
 " le FW."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Fil. est-il charge?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Plaque sur le lit?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Iteration"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Dernière impres."
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Échecs dernière imp."
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Gauche"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Ventilo gauche?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Gauche [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Niveau brill"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Niv. sombre"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Correction lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Ajuster Z en dir."
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Tout Charger"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Charger filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Charger la buse"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Test de chargmt."
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Charg. de la couleur"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Chargement du fil."
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Poulie lâche"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Fort"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MAJ FW MMU NECESS."
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Erreur interne du FW du MMU, réinitialisez le MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "Mode MMU"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "LE MMU NE RÉPOND PAS"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "Nouvelle tentative MMU: Restauration de la temperature..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELF TEST ÉCHEC"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "Échecs MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "Def. charg. MMU"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr ""
 "MMU ne répond pas correctement. Vérifiez le câblage et les connecteurs."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU ne répond pas. Vérifiez le câblage et les connecteurs."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU connecte"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Compens. aim."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Menu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Var. mesurée"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Je mesure la hauteur de reference du point de calibrage"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Mesh Bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Mode"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Changement de mode en cours..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Modèle"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Plus de details en ligne."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Moteur"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Déplacer X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Déplacer Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Déplacer Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Déplacer l'axe"
 
@@ -1277,63 +1274,62 @@ msgid "Moving selector"
 msgstr "Déplacement select."
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "I/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Nouvelle version de FW disponible:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Non"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Pas de carte SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Pas de mouvement."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Aucun"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Non connecte"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Ne tourne pas"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1341,33 +1337,33 @@ msgstr ""
 "lit."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Maintenant je vais préchauffer la buse pour du PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Retirez maintenant l'impression de test de la plaque en acier."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Buse"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Changement de buse"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Diam. buse"
 
@@ -1378,90 +1374,89 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
-msgstr ""
-"Anciens réglages trouvés. Le PID, les Esteps, etc. par défaut seront réglés."
+msgstr "Anciens réglages trouvés. Le PID, les Esteps, etc. par défaut seront réglés."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "1 fois"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSE ERREUR THERM."
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "Calib. PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "Calib. PID terminée"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "Calibration PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "Chauffe de la PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "Calib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "Échec de la calibration en PINDA"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr ""
-"La calibration en PINDA est terminée et activée. Il peut être désactivé dans"
-" le menu Réglages-> Calib. PINDA"
+"La calibration en PINDA est terminée et activée. Il peut être désactivé "
+"dans le menu Réglages-> Calib. PINDA"
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "ÉCHEC MOUV.T POULIE"
 
@@ -1472,13 +1467,13 @@ msgid "Parking selector"
 msgstr "Parquage sélecteur"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Pause de l'impr."
 
@@ -1489,7 +1484,7 @@ msgid "Performing cut"
 msgstr "Coupe en cours"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1498,7 +1493,7 @@ msgstr ""
 "premiers points. Si la buse accroche le papier, éteignez vite l'imprimante."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1507,27 +1502,27 @@ msgstr ""
 "l'assistant en redémarrant l'imprimante."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "SVP, vérifiez la connexion du capteur IR et déchargez le filament."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Vérifiez:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Nettoyez la plaque en acier et appuyez sur le bouton."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Nettoyez la buse pour la calibration. Cliquez une fois fait."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1535,7 +1530,7 @@ msgstr ""
 "pour le charger."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1544,104 +1539,104 @@ msgstr ""
 "pour le charger."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Veuillez d'abord charger un filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Ouvrez l'idler et retirez le filament manuellement."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Placez la plaque en acier sur le lit."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Appuyez sur le bouton pour décharger le filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Retirez immédiatement le filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Retirez d'abord les protections de transport."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Retirez la plaque en acier du lit."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Veuillez d'abord lancer la calibration XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "SVP, déchargez le filament et réessayez."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Mettez a jour le FW."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Merci de patienter"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Coup.de courant"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Préchauffage"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Préchauffez la buse!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Préchauffage de la buse. Merci de patienter."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Chauffe pour couper"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Chauf. pour remonter"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Chauffe pour charger"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Chauf.pour décharger"
 
@@ -1652,60 +1647,60 @@ msgid "Preparing blade"
 msgstr "Preparation lame"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "App. sur sur bouton"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Appuyez sur le bouton pour préchauffer la buse et continuer."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Impression annulée"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Vent. impr:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Impr. depuis la SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Impression en pause"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Temps d'impression"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Adr.IP imprimante:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
 msgstr "L'imprimante n'a pas encore été calibrée. Suivez le manuel."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diamètre de la buse diffère du G-Code. Continuer?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1714,7 +1709,7 @@ msgstr ""
 "annulée."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Le moteur de la poulie s'est bloqué. Assurez-vous que la poulie peut bouger "
@@ -1727,58 +1722,58 @@ msgid "Pushing filament"
 msgstr "Chargement filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "FILE PLEINE"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Arrière [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Récup. impression"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Renommer"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
 msgstr ""
-"L'outil de filament demandé n'est pas disponible sur ce matériel. Recherchez"
-" dans le G-Code un index d'outil hors plage (T0-T4)"
+"L'outil de filament demandé n'est pas disponible sur ce matériel. Recherchez "
+"dans le G-Code un index d'outil hors plage (T0-T4)"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Réinitialiser"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Réinit. calib. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Reprise impression"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Reprise de l'impr."
 
@@ -1789,7 +1784,7 @@ msgid "Retract from FINDA"
 msgstr "Rétraction de FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Ref."
 
@@ -1800,17 +1795,17 @@ msgid "Returning selector"
 msgstr "Retournement select."
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Droite"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Droite [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1819,39 +1814,39 @@ msgstr ""
 "et commencera du début. Continuer?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "Carte SD"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "ÉCHEC R.A.Z. SÉLECT."
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "ÉCHEC MOUV.T SELECT."
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "ARRÊTÉ"
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Recherche point calibration du lit"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Sélectionner"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1860,27 +1855,27 @@ msgstr ""
 "sélectionnez-le dans le menu."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Choix du filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Choisir langue"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Sélectionnez la temperature de préchauffage de la buse qui correspond à "
 "votre matériel."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Sélectionnez la température qui correspond à votre matériel."
 
@@ -1891,73 +1886,73 @@ msgid "Selecting fil. slot"
 msgstr "Sélection du fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Début selftest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Erreur selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Échec du selftest"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Le Selftest sera lancé pour caliber la remise à zéro précise sans capteur"
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Info capteur"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Capteur vérifié, retirez le filament maintenant."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Régler temp.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Réglages"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Déviat. sévère"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Plaque"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1970,23 +1965,23 @@ msgstr ""
 "%cRéinitialiser"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Afficher butées"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Furtif"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Déviat. légère"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1994,126 +1989,126 @@ msgstr ""
 "Certains fichiers ne seront pas tries. Max 100 fichiers tries par dossier."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problème rencontré, cliquez sur le bouton pour niveler l'axe Z..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Tri"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Tri des fichiers"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Son"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Vitesse"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Tourne"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Une temperature ambiante stable de 21-26C et un support stable sont requis."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statistiques"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Furtif"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Plaques en acier"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Arrêter impression"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Stricte"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Échangé"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIE THERMIQUE"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "ERREUR DU DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "RÉINIT DU DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "CC DU DRIVER TMC"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "ERR SURCHAUFFE TMC"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERR SOUS TENSION TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2122,27 +2117,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Modèle thermique non calibré."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Temperature"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Temperatures"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Test du filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2150,7 +2145,7 @@ msgstr ""
 "que ce soit qui bloque son mouvement."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2158,7 +2153,7 @@ msgstr ""
 "que ce que soit qui bloque son mouvement."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2168,71 +2163,70 @@ msgstr ""
 "jusqu'a atteindre la hauteur optimale. Consultez les photos dans le manuel."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
-msgstr ""
-"Il faut toujours effectuer la calibration Z. Veuillez suivre le manuel."
+msgstr "Il faut toujours effectuer la calibration Z. Veuillez suivre le manuel."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Heure"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Délai écoulé"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Totale"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Total des échecs"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Filament total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Temps total impr."
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Régler"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "DÉCHARGER MANUEL.T"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Déch."
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Décharger fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Déchargement fil."
 
@@ -2249,23 +2243,23 @@ msgid "Unloading to pulley"
 msgstr "Déchar.t vers poulie"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Vérification échouée, retirez le filament, et réessayez."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Tensions"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "ATT TMC TROP CHAUD"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2278,89 +2272,89 @@ msgstr ""
 "mode furtif"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Attente utilisateur."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Attente du refroidissement de la sonde PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Attente du refroidissement de la buse et lit"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Avert"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Attention: Types d'imprimante et de carte mere modifies"
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Attention: Type de carte mere modifie."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Attention: Type d'imprimante modifie"
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Déchargement du filament réussi?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Erreur de câblage"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Assistant"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "Correct-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "Details calib. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibration XYZ OK. L'écart sera corrigé automatiquement."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibration XYZ OK. Les axes X/Y sont légèrement non perpendiculaires. Bon "
 "boulot!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Calibration XYZ compromise. Les points de calibration en avant ne sont pas "
 "atteignables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
@@ -2368,112 +2362,119 @@ msgstr ""
 "atteignable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
-"Échec calibration XYZ. Le point de calibration du lit n'a pas été trouvé."
+"Échec calibration XYZ. Le point de calibration du lit n'a pas été "
+"trouvé."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Échec calibration XYZ. Les points de calibration en avant ne sont pas "
 "atteignables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Échec calibration XYZ. Consultez le manuel."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Échec calibration XYZ. Le point de calibration avant droit n'est pas "
 "atteignable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 "Calibration XYZ OK. Les axes X/Y sont perpendiculaires. Felicitations!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Distance Y du min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Correct-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Oui"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Vous pouvez toujours relancer l'Assistant dans Calibration > Assistant."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Correct-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Mesurer x-fois"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "Offset point [0;0]"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "et appuyez sur le bouton"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "pour charger le fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "pour décharger fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "inconnu"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "État inconnu"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Rafraîchir"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "Def. alim. MMU"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT ÉJECTÉ"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2482,12 +2483,12 @@ msgstr ""
 " chargé. Vérifiez les capteurs et le câblage."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "ÉCHOUÉ CHARGE A EXTR"
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2496,28 +2497,28 @@ msgstr ""
 " filament. Affiner l'étalonnage du capteur, si nécessaire."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU ERREUR"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Changes matériels"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Retirez le filament éjecté de l'avant de la MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2526,7 +2527,7 @@ msgstr ""
 "qu'aucun fil. n'est dans le sélecteur et que FINDA fonctionne correctement."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2534,49 +2535,57 @@ msgstr ""
 "vers la version 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Précharge à MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "Firmware MK3 détecté sur imprimante MK3S"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "Firmware MK3S détecté sur imprimante MK3"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "ERREUR INCONNUE"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Une erreur inattendue s'est produite."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Éjecter"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "CHANGEMENT DE FILAM."
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Charger"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "Changement de filament M600. Chargez un nouveau filament ou éjectez "
 "l'ancien."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Sensibilité"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Mesh bed leveling a échoué. Veuillez procéder à l'étalonnage Z."
 
@@ -2593,16 +2602,7 @@ msgstr "Ensemble pas prête"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Réimpresision"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Rafraîchir"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "Firmware MK3 détecté sur imprimante MK3S"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "Firmware MK3S détecté sur imprimante MK3"
+msgstr "Ré-imprimer"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 ou +ancien"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 ou +recent"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "niveau %s attendu"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Annuler"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Ajuster Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Tout est correct"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Tout est pret. Bonne impression!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Alphabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Tjrs"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Ambiant"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "Z-carriages gauche + droite tout en haut?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Assist"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Mise a 0 des axes"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Puiss.auto"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "Autocharge du fil."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Éviter broiement"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Axe"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Longueur de l'axe"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Retour"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Lit"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Chauffe du lit"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Lit termine"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Réglage lit"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +168,54 @@ msgstr ""
 "attente d'un reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Lit/Chauffage"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Statut courroie"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Test de courroie"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Coupure détectée. Reprendre impres.?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Brill."
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Luminosité"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "ERREUR COMMUNICATION"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Calibrer XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Calibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +224,13 @@ msgstr ""
 "l'axe Z jusqu'aux butées. Cliquez une fois fait."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Calibration Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,28 +239,28 @@ msgstr ""
 " Z jusqu'aux butées. Cliquez une fois fait."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Calib. mise a 0"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Calibration"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Calibration terminée"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Impossible de déplacer le Sélecteur ou l'Idler."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
@@ -267,128 +268,128 @@ msgstr ""
 "d'abord."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "Carte retiree"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Changez carte SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Changer filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Changement réussi!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Change correctement?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Vérifier axe X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Vérifier axe Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Vérifier axe Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Vérifier lit"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Vérifier butées"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Vérifier fichier"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Vérifier du hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Vérifier capteurs"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Verifications"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "Effacer l'error TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Couleur incorrecte"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Fait de community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Refroidissement"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Copier la langue choisie?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Crash détecté"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Crash détecté."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -400,34 +401,34 @@ msgstr ""
 "mode Normal"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Coupe filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Coupeur"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Date:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Sombre"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Désact."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Désactiver moteurs"
 
@@ -439,8 +440,8 @@ msgid "Disengaging idler"
 msgstr "Désenga.t de l'idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -450,7 +451,7 @@ msgstr ""
 "manuel, chap. Premiers pas."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -458,14 +459,14 @@ msgstr ""
 "Voulez-vous refaire l'étape pour réajuster la hauteur entre la buse et le "
 "lit?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Fait"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "Correct-E"
 
@@ -494,13 +495,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Att. Utilisateur"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "ERREUR:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Éjecter du MMU"
 
@@ -512,17 +513,17 @@ msgid "Ejecting filament"
 msgstr "Le fil. remonte"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Butée"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Butée non atteinte"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Butées"
 
@@ -534,45 +535,45 @@ msgid "Engaging idler"
 msgstr "Engagem.t de l'idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Extrudeur"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Infos extrudeur"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "F. autocharg."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "Detect bour F"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "Fin de F."
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT DEJA CHARGE"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NON DÉCLENCHÉE"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -582,7 +583,7 @@ msgstr ""
 "fonctionne."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -591,65 +592,65 @@ msgstr ""
 "vous que le filament peut bouger et que la FINDA fonctionne."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. BLOQUE"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "Action FS"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "CAPTEUR F. NON DECL."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "CAPTEUR F TROP TOT"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "CAPTEUR F: F. BLOQUE"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "ERREUR EXÉCUTION FW"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Stat. d'échec"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "Stat. d'échec MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Faux déclenchement"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Vitesse vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Test du ventilateur"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Vérif. vent."
 
@@ -678,46 +679,46 @@ msgid "Feeding to nozzle"
 msgstr "Chargement vers buse"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Fins filament"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Capteur Fil."
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrude et avec bonne couleur?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Filament non charge"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Capteur Fil."
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -726,7 +727,7 @@ msgstr ""
 "que le filament peut bouger et que le capteur fonctionne."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -735,7 +736,7 @@ msgstr ""
 " le filament a atteint le capteur f et que le capteur fonctionne."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -744,42 +745,42 @@ msgstr ""
 "Vérifiez le tube PTFE. Vérifiez que le capteur fonctionne."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Filament utilise"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "Fichier incomplet. Continuer qd meme?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Mouvement final"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Cal. 1ere couche"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Je vais lancer le selftest pour verifier les problèmes d'assemblage les plus"
 " communs."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Flux"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -788,28 +789,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Ventilo impr avant?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Avant [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Ventilos avt/gauche"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code a été préparé pour un niveau diff. Continuer?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -818,14 +819,14 @@ msgstr ""
 " Impression annulée."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code pour un type d'imprimante différent. Continue?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -834,12 +835,12 @@ msgstr ""
 "Impression annulée."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code a été préparé pour un FW plus récent. Cont.?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -848,35 +849,35 @@ msgstr ""
 "annulée."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "Config HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Chauffage/Thermistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Chauffe"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Chauffage désactivé par le compteur de sécurité."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Chauffe terminée."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -887,7 +888,7 @@ msgstr ""
 "à imprimer."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -896,8 +897,8 @@ msgstr ""
 "travers le processus d'installation"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Haut.puiss"
 
@@ -908,50 +909,50 @@ msgid "Homing"
 msgstr "Mise à zéro"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend à 280C! Buse changée et resserrée aux spécifications?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Vent. hotend:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr ""
 "Je vais maintenant lancer la calibration XYZ. Cela peut prendre jusqu'à 24 "
 "min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Je vais maintenant lancer la calibration Z."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "RAZ IDLER IMPOSSIBLE"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "ÉCHEC MOUV.T IDLER"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "VÉRIFIEZ FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "OUTIL INVALIDE"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -960,27 +961,27 @@ msgstr ""
 "Réglages - Config HW - Plaque en acier."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Amelioration du point de calibration du lit"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Écran d'info"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Init. carte SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Insérez le filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -989,7 +990,7 @@ msgstr ""
 "appuyez sur le bouton."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
@@ -997,273 +998,275 @@ msgstr ""
 " le FW."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Fil. est-il charge?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Plaque sur le lit?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteration"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Dernière impres."
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Échecs dernière imp."
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Gauche"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Ventilo gauche?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Gauche [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Niveau brill"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Niv. sombre"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Correction lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Ajuster Z en dir."
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Tout Charger"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Charger filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Charger la buse"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Test de chargmt."
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Charg. de la couleur"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Chargement du fil."
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Poulie lâche"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Fort"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MAJ FW MMU NECESS."
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Erreur interne du FW du MMU, réinitialisez le MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "Mode MMU"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "LE MMU NE RÉPOND PAS"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "Nouvelle tentative MMU: Restauration de la temperature..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELF TEST ÉCHEC"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "Échecs MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "Def. charg. MMU"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr ""
 "MMU ne répond pas correctement. Vérifiez le câblage et les connecteurs."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU ne répond pas. Vérifiez le câblage et les connecteurs."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU connecte"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Compens. aim."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Menu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Var. mesurée"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Je mesure la hauteur de reference du point de calibrage"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Mesh Bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Mode"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Changement de mode en cours..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Modèle"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Plus de details en ligne."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Moteur"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Déplacer X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Déplacer Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Déplacer Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Déplacer l'axe"
 
@@ -1274,62 +1277,63 @@ msgid "Moving selector"
 msgstr "Déplacement select."
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "I/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Nouvelle version de FW disponible:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Non"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Pas de carte SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Pas de mouvement."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Aucun"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Non connecte"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Ne tourne pas"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1337,33 +1341,33 @@ msgstr ""
 "lit."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Maintenant je vais préchauffer la buse pour du PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Retirez maintenant l'impression de test de la plaque en acier."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Buse"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Changement de buse"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Diam. buse"
 
@@ -1374,81 +1378,81 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Anciens réglages trouvés. Le PID, les Esteps, etc. par défaut seront réglés."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "1 fois"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSE ERREUR THERM."
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "Calib. PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "Calib. PID terminée"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "Calibration PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "Chauffe de la PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "Calib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "Échec de la calibration en PINDA"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1457,7 +1461,7 @@ msgstr ""
 " le menu Réglages-> Calib. PINDA"
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "ÉCHEC MOUV.T POULIE"
 
@@ -1468,13 +1472,13 @@ msgid "Parking selector"
 msgstr "Parquage sélecteur"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Pause de l'impr."
 
@@ -1485,7 +1489,7 @@ msgid "Performing cut"
 msgstr "Coupe en cours"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1494,7 +1498,7 @@ msgstr ""
 "premiers points. Si la buse accroche le papier, éteignez vite l'imprimante."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1503,27 +1507,27 @@ msgstr ""
 "l'assistant en redémarrant l'imprimante."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "SVP, vérifiez la connexion du capteur IR et déchargez le filament."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Vérifiez:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Nettoyez la plaque en acier et appuyez sur le bouton."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Nettoyez la buse pour la calibration. Cliquez une fois fait."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1531,7 +1535,7 @@ msgstr ""
 "pour le charger."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1540,104 +1544,104 @@ msgstr ""
 "pour le charger."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Veuillez d'abord charger un filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Ouvrez l'idler et retirez le filament manuellement."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Placez la plaque en acier sur le lit."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Appuyez sur le bouton pour décharger le filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Retirez immédiatement le filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Retirez d'abord les protections de transport."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Retirez la plaque en acier du lit."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Veuillez d'abord lancer la calibration XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "SVP, déchargez le filament et réessayez."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Mettez a jour le FW."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Merci de patienter"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Coup.de courant"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Préchauffage"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Préchauffez la buse!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Préchauffage de la buse. Merci de patienter."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Chauffe pour couper"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Chauf. pour remonter"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Chauffe pour charger"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Chauf.pour décharger"
 
@@ -1648,60 +1652,60 @@ msgid "Preparing blade"
 msgstr "Preparation lame"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "App. sur sur bouton"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Appuyez sur le bouton pour préchauffer la buse et continuer."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Impression annulée"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Vent. impr:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Impr. depuis la SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Impression en pause"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Temps d'impression"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Adr.IP imprimante:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
 msgstr "L'imprimante n'a pas encore été calibrée. Suivez le manuel."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diamètre de la buse diffère du G-Code. Continuer?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1710,7 +1714,7 @@ msgstr ""
 "annulée."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Le moteur de la poulie s'est bloqué. Assurez-vous que la poulie peut bouger "
@@ -1723,32 +1727,32 @@ msgid "Pushing filament"
 msgstr "Chargement filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "FILE PLEINE"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Arrière [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Récup. impression"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Renommer"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1757,24 +1761,24 @@ msgstr ""
 " dans le G-Code un index d'outil hors plage (T0-T4)"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Réinitialiser"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Réinit. calib. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Reprise impression"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Reprise de l'impr."
 
@@ -1785,7 +1789,7 @@ msgid "Retract from FINDA"
 msgstr "Rétraction de FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Ref."
 
@@ -1796,17 +1800,17 @@ msgid "Returning selector"
 msgstr "Retournement select."
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Droite"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Droite [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1815,39 +1819,39 @@ msgstr ""
 "et commencera du début. Continuer?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "Carte SD"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "ÉCHEC R.A.Z. SÉLECT."
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "ÉCHEC MOUV.T SELECT."
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "ARRÊTÉ"
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Recherche point calibration du lit"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Sélectionner"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1856,27 +1860,27 @@ msgstr ""
 "sélectionnez-le dans le menu."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Choix du filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Choisir langue"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Sélectionnez la temperature de préchauffage de la buse qui correspond à "
 "votre matériel."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Sélectionnez la température qui correspond à votre matériel."
 
@@ -1887,73 +1891,73 @@ msgid "Selecting fil. slot"
 msgstr "Sélection du fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Début selftest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Erreur selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Échec du selftest"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Le Selftest sera lancé pour caliber la remise à zéro précise sans capteur"
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Info capteur"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Capteur vérifié, retirez le filament maintenant."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Régler temp.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Réglages"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Déviat. sévère"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Plaque"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1966,23 +1970,23 @@ msgstr ""
 "%cRéinitialiser"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Afficher butées"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Furtif"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Déviat. légère"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1990,126 +1994,126 @@ msgstr ""
 "Certains fichiers ne seront pas tries. Max 100 fichiers tries par dossier."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problème rencontré, cliquez sur le bouton pour niveler l'axe Z..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Tri"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Tri des fichiers"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Son"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Vitesse"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Tourne"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Une temperature ambiante stable de 21-26C et un support stable sont requis."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statistiques"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Furtif"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Plaques en acier"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Arrêter impression"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Stricte"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Échangé"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIE THERMIQUE"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "ERREUR DU DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "RÉINIT DU DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "CC DU DRIVER TMC"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "ERR SURCHAUFFE TMC"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERR SOUS TENSION TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2118,27 +2122,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Modèle thermique non calibré."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Temperature"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Temperatures"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Test du filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2146,7 +2150,7 @@ msgstr ""
 "que ce soit qui bloque son mouvement."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2154,7 +2158,7 @@ msgstr ""
 "que ce que soit qui bloque son mouvement."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2164,7 +2168,7 @@ msgstr ""
 "jusqu'a atteindre la hauteur optimale. Consultez les photos dans le manuel."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2172,63 +2176,63 @@ msgstr ""
 "Il faut toujours effectuer la calibration Z. Veuillez suivre le manuel."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Heure"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Délai écoulé"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Totale"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Total des échecs"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Filament total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Temps total impr."
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Régler"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "DÉCHARGER MANUEL.T"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Déch."
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Décharger fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Déchargement fil."
 
@@ -2245,23 +2249,23 @@ msgid "Unloading to pulley"
 msgstr "Déchar.t vers poulie"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Vérification échouée, retirez le filament, et réessayez."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Tensions"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "ATT TMC TROP CHAUD"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2274,89 +2278,89 @@ msgstr ""
 "mode furtif"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Attente utilisateur."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Attente du refroidissement de la sonde PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Attente du refroidissement de la buse et lit"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Avert"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Attention: Types d'imprimante et de carte mere modifies"
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Attention: Type de carte mere modifie."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Attention: Type d'imprimante modifie"
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Déchargement du filament réussi?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Erreur de câblage"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Assistant"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "Correct-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "Details calib. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibration XYZ OK. L'écart sera corrigé automatiquement."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibration XYZ OK. Les axes X/Y sont légèrement non perpendiculaires. Bon "
 "boulot!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Calibration XYZ compromise. Les points de calibration en avant ne sont pas "
 "atteignables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
@@ -2364,118 +2368,112 @@ msgstr ""
 "atteignable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Échec calibration XYZ. Le point de calibration du lit n'a pas été trouvé."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Échec calibration XYZ. Les points de calibration en avant ne sont pas "
 "atteignables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Échec calibration XYZ. Consultez le manuel."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Échec calibration XYZ. Le point de calibration avant droit n'est pas "
 "atteignable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 "Calibration XYZ OK. Les axes X/Y sont perpendiculaires. Felicitations!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Distance Y du min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Correct-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Oui"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Vous pouvez toujours relancer l'Assistant dans Calibration > Assistant."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Correct-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Mesurer x-fois"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "Offset point [0;0]"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "et appuyez sur le bouton"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "pour charger le fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "pour décharger fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "inconnu"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "État inconnu"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Rafraîchir"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "Def. alim. MMU"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT ÉJECTÉ"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2484,12 +2482,12 @@ msgstr ""
 " chargé. Vérifiez les capteurs et le câblage."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "ÉCHOUÉ CHARGE A EXTR"
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2498,28 +2496,28 @@ msgstr ""
 " filament. Affiner l'étalonnage du capteur, si nécessaire."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU ERREUR"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Changes matériels"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Retirez le filament éjecté de l'avant de la MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2528,7 +2526,7 @@ msgstr ""
 "qu'aucun fil. n'est dans le sélecteur et que FINDA fonctionne correctement."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2536,57 +2534,49 @@ msgstr ""
 "vers la version 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Précharge à MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "Firmware MK3 détecté sur imprimante MK3S"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "Firmware MK3S détecté sur imprimante MK3"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "ERREUR INCONNUE"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Une erreur inattendue s'est produite."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Éjecter"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "CHANGEMENT DE FILAM."
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Charger"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "Changement de filament M600. Chargez un nouveau filament ou éjectez "
 "l'ancien."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Sensibilité"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Mesh bed leveling a échoué. Veuillez procéder à l'étalonnage Z."
 
@@ -2600,10 +2590,19 @@ msgstr "Ensemble prête"
 msgid "Set not Ready"
 msgstr "Ensemble pas prête"
 
-#. MSG_REPRINT c=13
-#: ../../Firmware/ultralcd.cpp:5189
+#. MSG_REPRINT c=7
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Réimpresision"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Rafraîchir"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "Firmware MK3 détecté sur imprimante MK3S"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "Firmware MK3S détecté sur imprimante MK3"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2590,7 +2590,7 @@ msgstr "Ensemble prête"
 msgid "Set not Ready"
 msgstr "Ensemble pas prête"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Réimpresision"

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 ili stariji"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 ili noviji"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "%s level ocekivan"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Otkazati"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Podesavanje Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Sve je u redu"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Sve je gotovo. Sretno printanje!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Uvijek"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Ambijent"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "Jesu lijevi i desni Z-nosaci podignuti?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Pomoc"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Pocetna tocka"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Auto napaj"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "Autopunj filamenta"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Auto punjenje fil. je aktivno, pritisnite gumb i umetnite fil.."
@@ -113,52 +112,52 @@ msgid "Avoiding grind"
 msgstr "Sprecavanje mljevenj"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Os"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Duljina osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Natrag"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Podloga"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Podloga se zagrijava"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Podloga zagrijana"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Podloga ispravna"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +166,54 @@ msgstr ""
 "mlaznici? Ceka se resetiranje."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Grijac/Podloga"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Status remena"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Testiranje remena"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Doslo je do gasenja. Oporaviti print?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Svijet"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Svjetlina"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "KOM. GRESKA"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Kalibrirajte XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Kalibrirajte Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +222,13 @@ msgstr ""
 "Kliknite kada je zavrseno."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Kalibriracija Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,156 +237,156 @@ msgstr ""
 "Kliknite kada je zavrseno."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Kalibracija nultocke"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Kalibriranje"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Kalibracija gotova"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Ne mogu pomaknuti Odabirac ili Klizac."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "Nije moguce izvrsiti radnju, filament je već napunjen. Prvo ga isprazni."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "Kartica je uklonjena"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Promjeni SD karti."
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Promijeni filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Promijena uspjesna!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Ispravno izmjenjeno?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Provjera X osi"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Provjera Y osi"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Provjera Z osi"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Provjera podloge"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Provjera granicnika"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Provjera datoteke"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Provjera hotenda"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Provjera senzora"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Provjere"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "Obriši TM pogrešku"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Boja nije ispravna"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Napravilo zajedno"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Nast."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Ohladi"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Kopirati odabrani jezik?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Udar"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Udar detekti."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Udar otkriven."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -395,34 +394,34 @@ msgid ""
 msgstr "Detekcija udarca moze biti ukljuceno samo u Normalnom nacinu rada"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Odrezite fil."
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Rezac"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Tamno"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Onemogu."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Onemoguci stepere"
 
@@ -434,8 +433,8 @@ msgid "Disengaging idler"
 msgstr "Iskl. kliznika"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -446,7 +445,7 @@ msgstr ""
 "prvog sloja."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -454,14 +453,14 @@ msgstr ""
 "Zelite li ponoviti zadnji korak za ponovno podesavanje udaljenosti izmedu "
 "mlaznice i grijace podloge?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Gotov"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "E-ispravan"
 
@@ -490,13 +489,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Cekam korisnika"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "POGRESKA:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Izbaci iz MMU"
 
@@ -508,17 +507,17 @@ msgid "Ejecting filament"
 msgstr "Izbacivanje fil."
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Granicnik"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Granicnik nije aktiv"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Granicnici"
 
@@ -530,45 +529,45 @@ msgid "Engaging idler"
 msgstr "Angaziranje klizaca"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Ekstruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Info o ekstruderu"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "F. auto.punj"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "F. zastopan"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "F. isteko"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT VEC NAPUNJ."
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA SE NIJE AKT."
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -577,7 +576,7 @@ msgstr ""
 "ručno. Provjerite može li se filament pomicati i FINDA radi."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -586,65 +585,65 @@ msgstr ""
 "filament pomicati i FINDA radi."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. ZAPEO"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "FS Akcija"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENZOR NIJE  AKTIV."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENZOR PRERANO"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENZOR FIL. ZAPEO"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "FW GRESKA IZVRSENJA"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Neuspjesna stat"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "Neuspjes. MMU stat"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Lazno aktiviranje"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Brzina vent"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Test ventilatora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Provjera vent"
 
@@ -673,46 +672,46 @@ msgid "Feeding to nozzle"
 msgstr "Dovod do mlaznice"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Bez filmaneta"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Ekstrudiranje fil.s sa ispravnom bojom?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Fil. nije napunjen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Senzor filamenta"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -721,7 +720,7 @@ msgstr ""
 " se filament moze pomaknuti i da senzor radi"
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -730,7 +729,7 @@ msgstr ""
 " je filament dosegao fsenzor i da senzor radi."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -739,42 +738,42 @@ msgstr ""
 " li je nešto zapelo u PTFE cijevi. Ocitava li senzor ispravno."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Iskoristeni fil."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "Datoteka je nepotpuna. Svejedno nastaviti?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Zavrsni pokreti"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Prvi sloj kalib."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Prvo cu pokrenuti samotestiranje kako bih provjerio najcesce probleme sa "
 "montazom."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Protok"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -783,28 +782,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Prednji print vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Prednj str[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Prednji/lijevi vent"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-kod izrezan za drugu razinu. Nastavite?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -813,14 +812,14 @@ msgstr ""
 "otkazan."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-kod izrezan za drugu vrstu printera. Nastavite?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -829,12 +828,12 @@ msgstr ""
 "je otkazan."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-kod izrezan za noviji firmware. Nastavite?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -843,35 +842,35 @@ msgstr ""
 "otkazan."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "HW podesavanje"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Grijac/Termostat"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Grijanje"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Grijanje je onemoguceno sigurnosnim mjeracem vremena."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Grijanje obavljeno."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -882,7 +881,7 @@ msgstr ""
 "printanje."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -891,8 +890,8 @@ msgstr ""
 "postupak postavljanja?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Visoka sna"
 
@@ -903,49 +902,49 @@ msgid "Homing"
 msgstr "Navodjenje"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 "Zagrijati na 280C! Mlaznica promijenjena i stegnuta prema specifikacijama?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Hotend vent:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Sada cu pokrenuti xyz kalibraciju. Trebat ce do 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Sada cu pokrenuti z kalibraciju."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "KLIZAC NIJE PODESEN"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "KLIZAC NIJE POMAKNUT"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "PREGLED FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "NEVALJAN ALAT"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -954,27 +953,27 @@ msgstr ""
 "postavke u Postavke - HW Podesavanje - Celicne ploce."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Poboljšanje točke kalibracije podloge"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Info zaslon"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Obrada SD kartice"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Umetnite filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -982,7 +981,7 @@ msgstr ""
 "Umetnite filament (nemojte ga puniti) u ekstruder i zatim pritisnite gumb."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
@@ -990,274 +989,272 @@ msgstr ""
 "firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Je li filament napunjen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Je li celicna ploca na grijanoj podlozi?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Ponavljanje"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Zadnji print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Zadnji neusp. print"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Lijevo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Lijevi hotend vent?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Lijeva str[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Razina svjet"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Razina zatam"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Lin. ispravak"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Live podesavanje Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Puni sve"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Napunite fil."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Punjenje u mlazn"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Punjenje test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Ucitavanje boje"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Punjenje filamenta"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Labava remenica"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Glasno"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "POTREBNO AZURIRANJE"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Interna pogreska firmware MMU-a, resetirajte MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NE ODGOVARA"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Ponovni pokusaj: Vracanje temperature..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST N USPIO"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "MMU ne uspijeva"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "Neusp. MMU punj"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU ne reagira ispravno. Provjerite ozicenje i konektore."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU ne reagira. Provjerite ozicenje i konektore."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU spojen"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Magnet. komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Nazad"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Mjereni nagib"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Mjerenje referentne visine kalibracijske tocke"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Mreza"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Izrav. mrez. podl"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Promjena moda u tijeku..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Vise detalja online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Pomaknite X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Pomaknite Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Pomaknite Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Pomaknite os"
 
@@ -1268,63 +1265,62 @@ msgid "Moving selector"
 msgstr "Pomicanje odabiraca"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Dostupna nova verzija firmwera:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Ne"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Nema SD kartice"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Bez pomaka."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Nema"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Nije povezano"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Ne okrece se"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1332,33 +1328,33 @@ msgstr ""
 "podloge."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Sada cu zagrijati mlaznicu za PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Sada uklonite probni print sa celicne ploce."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Mlaznica"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Promjena mlaznice"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Mlaznica."
 
@@ -1369,80 +1365,80 @@ msgid "OK"
 msgstr "Ok"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Pronadene stare postavke. Postavit ce se zadani PID, Esteps itd."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "Jednom"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUZIRAN TERMAL EROR"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "PID kal. zavrsena"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "PID kalibracija"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "PINDA se Zagrijava"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "Kalibracija PINDA nije uspjela"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1451,7 +1447,7 @@ msgstr ""
 "Postavke->PINDA. kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "REMENICA SE NE MICE"
 
@@ -1462,13 +1458,13 @@ msgid "Parking selector"
 msgstr "Selektor parkiranja"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Pauzirajte print"
 
@@ -1479,7 +1475,7 @@ msgid "Performing cut"
 msgstr "Izvodjenje reza"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1488,7 +1484,7 @@ msgstr ""
 "mlaznica uhvati papir, odmah iskljucite printer."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1497,33 +1493,33 @@ msgstr ""
 "ponovnim pokretanjem printera."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Provjerite IR prikljucak senzora, izvadite filament ako postoji."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Molimo provjerite:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Ocistite grijacu podlogu, a zatim pritisnite gumb."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Molimo ocistite mlaznicu radi kalibracije. Kliknite kada ste gotovi."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Umetnite filament u ekstruder, a zatim pritisnite gumb za punjenje."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1531,104 +1527,104 @@ msgstr ""
 "Umetnite filament u prvu cijev MMU-a, a zatim pritisnite gumb za punjenje."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Molimo prvo ubacite filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Molimo otvorite klizac i rucno uklonite filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Stavite celicnu plocu na grijacu podlogu."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Pritisnite gumb za praznjenje filamenta"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Molimo odmah izvucite filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Najprije uklonite prijevozne osloce."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Molimo uklonite celicnu plocu sa grijace podloge."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Prvo pokrenite XYZ kalibraciju."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Prvo izvadite filament, a zatim ponovite ovu radnju."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Molimo nadogradite."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Molimo pricekajte"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Prekidi struje"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Predgrijavanje"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Predgr. mlaznicu!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Predgrijavanje mlaznice. Molim vas pricekajte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Predgr. za rezanje"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Predgr. za izbaci."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Predgr. za punjenje"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Predgr. za praznj."
 
@@ -1639,48 +1635,48 @@ msgid "Preparing blade"
 msgstr "Priprema ostrice"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Pritisnite gumb"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pritisnite gumb za predgrijavanje mlaznice i nastavite."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Print je prekinut"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Vent printa:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Printaj sa SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Print pauziran"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Vrijeme printanja"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Printer IP Adr:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1689,12 +1685,12 @@ msgstr ""
 "koraci, odjeljak Tijek kalibracije."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Promjer mlaznice razlikuje se od G-koda. Nastavite?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1703,7 +1699,7 @@ msgstr ""
 "vrijednost u postavkama. Print je otkazan."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Motor remenice zastao. Provjerite moze li se remenica pomicati i provjerite "
@@ -1716,32 +1712,32 @@ msgid "Pushing filament"
 msgstr "Guranje filamenta"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "RED PUN"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "RPi utor"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Zad. str.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Oporavak printa"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Preimenuj"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1750,24 +1746,24 @@ msgstr ""
 "za indeks alata izvan raspona (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Resetiraj"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Nastavite print"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Nastavak printa"
 
@@ -1778,7 +1774,7 @@ msgid "Retract from FINDA"
 msgstr "Izvuci iz FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Retry"
 
@@ -1789,17 +1785,17 @@ msgid "Returning selector"
 msgstr "Povratak izbornika"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Tocno"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Desna str.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1808,39 +1804,39 @@ msgstr ""
 "ispocetka. Nastavite?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "SD karti"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "IZBORNIK NE PODESEN"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "IZBORNIK SE NE MICE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "ZAUSTAVLJENO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Trazenje tocke kalibracije podloge"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Odaberi"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1849,27 +1845,27 @@ msgstr ""
 "zaslonu."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Odaberi filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Izaberi jezik"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Odaberite temperaturu predgrijavanja mlaznice koja odgovara vasem "
 "materijalu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Odaberite temperaturu koja odgovara vasem materijalu."
 
@@ -1880,74 +1876,74 @@ msgid "Selecting fil. slot"
 msgstr "Odabir fil. utora"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Samotestiranje OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Pocetak selftesta"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Selftest error!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Selftest nije uspio"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Provest ce se selftest radi kalibracije preciznog ponovnog postavljanja bez "
 "senzora."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Info senzora"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor je provjeren, odmah uklonite filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Postavi temperaturu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Postavke"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Veliki nagib"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Ploca"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1960,23 +1956,23 @@ msgstr ""
 "%cResetiraj"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Pokazi granicnike"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Tih"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Lagani nagib"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1985,127 +1981,127 @@ msgstr ""
 " je 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Naisao je neki problem, nametnuto Z-niveliranje..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Vrsta"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Sortiranje datoteka"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Brzina"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Okrece se"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Potrebna je stabilna temperatura okoline 21-26C, potrebno je cvrsto "
 "postolje."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Tiho"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Celicna ploca"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Zaustavi print"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Strogo"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Podrska"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Zamjenjeno"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "TERMALNA ANOMALIJA"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "TMC GRESKA DRAJVERA"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "TMC RESET DRAJVERA"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRAJVER SKRACEN"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC GRESKA PREGRIJAN"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC NISKA VOLTAZA"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2114,27 +2110,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Toplinski model još nije kalibriran."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Temperature"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Testiram filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2142,7 +2138,7 @@ msgstr ""
 "njegovo kretanje."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2150,7 +2146,7 @@ msgstr ""
 "sprjecava njegovo kretanje."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2160,7 +2156,7 @@ msgstr ""
 "optimalnu visinu. Provjerite slike u prirucniku (poglavlje Kalibracija)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2169,63 +2165,63 @@ msgstr ""
 "poglavlje Prvi koraci, odjeljak Tijek kalibracije."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Vrijeme"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Pauza"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Ukupno"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Totalne pogreske"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Totalno filamenta"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Vrijeme printanja"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Ugodi"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "ISPRAZNI RUCNO"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Prazni"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Ispraznite fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Praznjenje filamenta"
 
@@ -2242,23 +2238,23 @@ msgid "Unloading to pulley"
 msgstr "PRAZNJ DO REMENICE"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Provjera nije uspjela, uklonite filament i pokusajte ponovno."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Voltaza"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "UPOZORENJE TMC VRUC"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2270,194 +2266,200 @@ msgstr ""
 "u tihom modu"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Ceka se korisnik..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Ceka se hladenje PINDA sonde"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Ceka se hladjenje mlaznice i podloge"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Upozore"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Upozorenje: promijenjeni su i tip printera i tip maticne ploce."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Upozorenje: tip maticne ploce je promijenjen."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Upozorenje: promijenjena je vrsta printera."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Je li praznjenje fil. bilo uspjesno?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Greska u ozicenju"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Carobnjak"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "X-ispravan"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "XYZ detalji kal"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ kalibracija u redu. Iskrivljenost ce se automatski ispraviti."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ kalibracija je u redu. Osi X/Y su malo nagnute. Bravo!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "XYZ kalibracija je ugrozena. Prednje kalibracijske tocke nisu dostupne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ kalibracija je ugrozena. Desna prednja tocka kalibracije nije dostupna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "XYZ kalibracija nije uspjela. Tocka kalibracije podloga nije pronadena."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "XYZ kalibracija nije uspjela. Prednje kalibracijske tocke nisu dostupne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracija nije uspjela. Molimo pogledajte prirucnik."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "XYZ kalibracija nije uspjela. Desna prednja tocka kalibracije nije dostupna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ kalibracija u redu. Osi X/Y su okomite. Cestitamo!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Y distanca od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Y-ispravan"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Da"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Carobnjak uvijek mozete nastaviti iz Kalibracija -> Carobnjak."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Z-ispravan"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Z-sonda br."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] razmak tocke"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "i pritisnite gumb"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "da napuni filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "da isprazni filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "nepoznato"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "nepoznato stanje"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Osvjeziti"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "Neusp. MMU nap"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT IZBAČEN"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2466,12 +2468,12 @@ msgstr ""
 " senzore i ožičenje."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "NEUSPJEH PUNI EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2480,28 +2482,28 @@ msgstr ""
 "Poboljšajte kalibraciju senzora, ako je potrebno."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU GRESKA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Materijal razmjene"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Uklonite izbačenu nit s prednje strane MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2510,7 +2512,7 @@ msgstr ""
 "jedna nit nije u selektoru i da FINDA radi ispravno."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2518,47 +2520,55 @@ msgstr ""
 "3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Predpunjenje MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "MK3 firmware otkriven na MK3S printeru"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "MK3S firmware detektiran na MK3 printeru"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "NEPOZNATA POGREŠKA"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Došlo je do neočekivane pogreške."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Izbaciti"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "PROMJENA FILAMENTA"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Napunite"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Promjena filamenta M600. Stavite novu nit ili izbacite staru."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Osjetljivost"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Niveliranje podloge nije uspijelo. Pokrenite Z kalibraciju."
 
@@ -2575,16 +2585,7 @@ msgstr "Set nije spreman"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Pretisak"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Osvjeziti"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "MK3 firmware otkriven na MK3S printeru"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "MK3S firmware detektiran na MK3 printeru"
+msgstr "Ponovno tiskanje"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Uklonite stari fil. i pritisnite gumb za pocetak stavljanja novog."

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2582,6 +2582,11 @@ msgstr "Set spreman"
 msgid "Set not Ready"
 msgstr "Set nije spreman"
 
+#. MSG_REPRINT c=8
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Pretisak"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Uklonite stari fil. i pritisnite gumb za pocetak stavljanja novog."
 

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 ili stariji"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 ili noviji"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "%s level ocekivan"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Otkazati"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Podesavanje Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Sve je u redu"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Sve je gotovo. Sretno printanje!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Uvijek"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Ambijent"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "Jesu lijevi i desni Z-nosaci podignuti?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Pomoc"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Pocetna tocka"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Auto napaj"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "Autopunj filamenta"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Auto punjenje fil. je aktivno, pritisnite gumb i umetnite fil.."
@@ -112,52 +113,52 @@ msgid "Avoiding grind"
 msgstr "Sprecavanje mljevenj"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Os"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Duljina osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Natrag"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Podloga"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Podloga se zagrijava"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Podloga zagrijana"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Podloga ispravna"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,54 +167,54 @@ msgstr ""
 "mlaznici? Ceka se resetiranje."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Grijac/Podloga"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Status remena"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Testiranje remena"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Doslo je do gasenja. Oporaviti print?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Svijet"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Svjetlina"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "KOM. GRESKA"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Kalibrirajte XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Kalibrirajte Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +223,13 @@ msgstr ""
 "Kliknite kada je zavrseno."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Kalibriracija Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,156 +238,156 @@ msgstr ""
 "Kliknite kada je zavrseno."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Kalibracija nultocke"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Kalibriranje"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Kalibracija gotova"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Ne mogu pomaknuti Odabirac ili Klizac."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "Nije moguce izvrsiti radnju, filament je već napunjen. Prvo ga isprazni."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "Kartica je uklonjena"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Promjeni SD karti."
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Promijeni filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Promijena uspjesna!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Ispravno izmjenjeno?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Provjera X osi"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Provjera Y osi"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Provjera Z osi"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Provjera podloge"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Provjera granicnika"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Provjera datoteke"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Provjera hotenda"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Provjera senzora"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Provjere"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "Obriši TM pogrešku"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Boja nije ispravna"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Napravilo zajedno"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Nast."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Ohladi"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Kopirati odabrani jezik?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Udar"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Udar detekti."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Udar otkriven."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -394,34 +395,34 @@ msgid ""
 msgstr "Detekcija udarca moze biti ukljuceno samo u Normalnom nacinu rada"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Odrezite fil."
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Rezac"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Tamno"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Onemogu."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Onemoguci stepere"
 
@@ -433,8 +434,8 @@ msgid "Disengaging idler"
 msgstr "Iskl. kliznika"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -445,7 +446,7 @@ msgstr ""
 "prvog sloja."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -453,14 +454,14 @@ msgstr ""
 "Zelite li ponoviti zadnji korak za ponovno podesavanje udaljenosti izmedu "
 "mlaznice i grijace podloge?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Gotov"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "E-ispravan"
 
@@ -489,13 +490,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Cekam korisnika"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "POGRESKA:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Izbaci iz MMU"
 
@@ -507,17 +508,17 @@ msgid "Ejecting filament"
 msgstr "Izbacivanje fil."
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Granicnik"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Granicnik nije aktiv"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Granicnici"
 
@@ -529,45 +530,45 @@ msgid "Engaging idler"
 msgstr "Angaziranje klizaca"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Ekstruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Info o ekstruderu"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "F. auto.punj"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "F. zastopan"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "F. isteko"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT VEC NAPUNJ."
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA SE NIJE AKT."
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -576,7 +577,7 @@ msgstr ""
 "ručno. Provjerite može li se filament pomicati i FINDA radi."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -585,65 +586,65 @@ msgstr ""
 "filament pomicati i FINDA radi."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. ZAPEO"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "FS Akcija"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENZOR NIJE  AKTIV."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENZOR PRERANO"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENZOR FIL. ZAPEO"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "FW GRESKA IZVRSENJA"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Neuspjesna stat"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "Neuspjes. MMU stat"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Lazno aktiviranje"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Brzina vent"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Test ventilatora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Provjera vent"
 
@@ -672,46 +673,46 @@ msgid "Feeding to nozzle"
 msgstr "Dovod do mlaznice"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Bez filmaneta"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Ekstrudiranje fil.s sa ispravnom bojom?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Fil. nije napunjen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Senzor filamenta"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -720,7 +721,7 @@ msgstr ""
 " se filament moze pomaknuti i da senzor radi"
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -729,7 +730,7 @@ msgstr ""
 " je filament dosegao fsenzor i da senzor radi."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -738,42 +739,42 @@ msgstr ""
 " li je nešto zapelo u PTFE cijevi. Ocitava li senzor ispravno."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Iskoristeni fil."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "Datoteka je nepotpuna. Svejedno nastaviti?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Zavrsni pokreti"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Prvi sloj kalib."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Prvo cu pokrenuti samotestiranje kako bih provjerio najcesce probleme sa "
 "montazom."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Protok"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -782,28 +783,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Prednji print vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Prednj str[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Prednji/lijevi vent"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-kod izrezan za drugu razinu. Nastavite?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -812,14 +813,14 @@ msgstr ""
 "otkazan."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-kod izrezan za drugu vrstu printera. Nastavite?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -828,12 +829,12 @@ msgstr ""
 "je otkazan."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-kod izrezan za noviji firmware. Nastavite?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -842,35 +843,35 @@ msgstr ""
 "otkazan."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "HW podesavanje"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Grijac/Termostat"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Grijanje"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Grijanje je onemoguceno sigurnosnim mjeracem vremena."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Grijanje obavljeno."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -881,7 +882,7 @@ msgstr ""
 "printanje."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -890,8 +891,8 @@ msgstr ""
 "postupak postavljanja?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Visoka sna"
 
@@ -902,49 +903,49 @@ msgid "Homing"
 msgstr "Navodjenje"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 "Zagrijati na 280C! Mlaznica promijenjena i stegnuta prema specifikacijama?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Hotend vent:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Sada cu pokrenuti xyz kalibraciju. Trebat ce do 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Sada cu pokrenuti z kalibraciju."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "KLIZAC NIJE PODESEN"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "KLIZAC NIJE POMAKNUT"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "PREGLED FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "NEVALJAN ALAT"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -953,27 +954,27 @@ msgstr ""
 "postavke u Postavke - HW Podesavanje - Celicne ploce."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Poboljšanje točke kalibracije podloge"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Info zaslon"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Obrada SD kartice"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Umetnite filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -981,7 +982,7 @@ msgstr ""
 "Umetnite filament (nemojte ga puniti) u ekstruder i zatim pritisnite gumb."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
@@ -989,272 +990,274 @@ msgstr ""
 "firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Je li filament napunjen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Je li celicna ploca na grijanoj podlozi?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Ponavljanje"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Zadnji print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Zadnji neusp. print"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Lijevo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Lijevi hotend vent?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Lijeva str[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Razina svjet"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Razina zatam"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Lin. ispravak"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Live podesavanje Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Puni sve"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Napunite fil."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Punjenje u mlazn"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Punjenje test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Ucitavanje boje"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Punjenje filamenta"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Labava remenica"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Glasno"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "POTREBNO AZURIRANJE"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Interna pogreska firmware MMU-a, resetirajte MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NE ODGOVARA"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Ponovni pokusaj: Vracanje temperature..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST N USPIO"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "MMU ne uspijeva"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "Neusp. MMU punj"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU ne reagira ispravno. Provjerite ozicenje i konektore."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU ne reagira. Provjerite ozicenje i konektore."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU spojen"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Magnet. komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Nazad"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Mjereni nagib"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Mjerenje referentne visine kalibracijske tocke"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Mreza"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Izrav. mrez. podl"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Promjena moda u tijeku..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Vise detalja online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Pomaknite X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Pomaknite Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Pomaknite Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Pomaknite os"
 
@@ -1265,62 +1268,63 @@ msgid "Moving selector"
 msgstr "Pomicanje odabiraca"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Dostupna nova verzija firmwera:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Ne"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Nema SD kartice"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Bez pomaka."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Nema"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Nije povezano"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Ne okrece se"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1328,33 +1332,33 @@ msgstr ""
 "podloge."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Sada cu zagrijati mlaznicu za PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Sada uklonite probni print sa celicne ploce."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Mlaznica"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Promjena mlaznice"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Mlaznica."
 
@@ -1365,80 +1369,80 @@ msgid "OK"
 msgstr "Ok"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Pronadene stare postavke. Postavit ce se zadani PID, Esteps itd."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "Jednom"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUZIRAN TERMAL EROR"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "PID kal. zavrsena"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "PID kalibracija"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "PINDA se Zagrijava"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "Kalibracija PINDA nije uspjela"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1447,7 +1451,7 @@ msgstr ""
 "Postavke->PINDA. kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "REMENICA SE NE MICE"
 
@@ -1458,13 +1462,13 @@ msgid "Parking selector"
 msgstr "Selektor parkiranja"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Pauzirajte print"
 
@@ -1475,7 +1479,7 @@ msgid "Performing cut"
 msgstr "Izvodjenje reza"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1484,7 +1488,7 @@ msgstr ""
 "mlaznica uhvati papir, odmah iskljucite printer."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1493,33 +1497,33 @@ msgstr ""
 "ponovnim pokretanjem printera."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Provjerite IR prikljucak senzora, izvadite filament ako postoji."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Molimo provjerite:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Ocistite grijacu podlogu, a zatim pritisnite gumb."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Molimo ocistite mlaznicu radi kalibracije. Kliknite kada ste gotovi."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Umetnite filament u ekstruder, a zatim pritisnite gumb za punjenje."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1527,104 +1531,104 @@ msgstr ""
 "Umetnite filament u prvu cijev MMU-a, a zatim pritisnite gumb za punjenje."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Molimo prvo ubacite filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Molimo otvorite klizac i rucno uklonite filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Stavite celicnu plocu na grijacu podlogu."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Pritisnite gumb za praznjenje filamenta"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Molimo odmah izvucite filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Najprije uklonite prijevozne osloce."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Molimo uklonite celicnu plocu sa grijace podloge."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Prvo pokrenite XYZ kalibraciju."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Prvo izvadite filament, a zatim ponovite ovu radnju."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Molimo nadogradite."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Molimo pricekajte"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Prekidi struje"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Predgrijavanje"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Predgr. mlaznicu!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Predgrijavanje mlaznice. Molim vas pricekajte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Predgr. za rezanje"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Predgr. za izbaci."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Predgr. za punjenje"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Predgr. za praznj."
 
@@ -1635,48 +1639,48 @@ msgid "Preparing blade"
 msgstr "Priprema ostrice"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Pritisnite gumb"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pritisnite gumb za predgrijavanje mlaznice i nastavite."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Print je prekinut"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Vent printa:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Printaj sa SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Print pauziran"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Vrijeme printanja"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Printer IP Adr:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1685,12 +1689,12 @@ msgstr ""
 "koraci, odjeljak Tijek kalibracije."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Promjer mlaznice razlikuje se od G-koda. Nastavite?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1699,7 +1703,7 @@ msgstr ""
 "vrijednost u postavkama. Print je otkazan."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Motor remenice zastao. Provjerite moze li se remenica pomicati i provjerite "
@@ -1712,32 +1716,32 @@ msgid "Pushing filament"
 msgstr "Guranje filamenta"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "RED PUN"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "RPi utor"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Zad. str.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Oporavak printa"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Preimenuj"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1746,24 +1750,24 @@ msgstr ""
 "za indeks alata izvan raspona (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Resetiraj"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Nastavite print"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Nastavak printa"
 
@@ -1774,7 +1778,7 @@ msgid "Retract from FINDA"
 msgstr "Izvuci iz FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Retry"
 
@@ -1785,17 +1789,17 @@ msgid "Returning selector"
 msgstr "Povratak izbornika"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Tocno"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Desna str.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1804,39 +1808,39 @@ msgstr ""
 "ispocetka. Nastavite?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "SD karti"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "IZBORNIK NE PODESEN"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "IZBORNIK SE NE MICE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "ZAUSTAVLJENO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Trazenje tocke kalibracije podloge"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Odaberi"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1845,27 +1849,27 @@ msgstr ""
 "zaslonu."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Odaberi filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Izaberi jezik"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Odaberite temperaturu predgrijavanja mlaznice koja odgovara vasem "
 "materijalu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Odaberite temperaturu koja odgovara vasem materijalu."
 
@@ -1876,74 +1880,74 @@ msgid "Selecting fil. slot"
 msgstr "Odabir fil. utora"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Samotestiranje OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Pocetak selftesta"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Selftest error!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Selftest nije uspio"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Provest ce se selftest radi kalibracije preciznog ponovnog postavljanja bez "
 "senzora."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Info senzora"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor je provjeren, odmah uklonite filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Postavi temperaturu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Postavke"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Veliki nagib"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Ploca"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1956,23 +1960,23 @@ msgstr ""
 "%cResetiraj"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Pokazi granicnike"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Tih"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Lagani nagib"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1981,127 +1985,127 @@ msgstr ""
 " je 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Naisao je neki problem, nametnuto Z-niveliranje..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Vrsta"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Sortiranje datoteka"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Brzina"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Okrece se"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Potrebna je stabilna temperatura okoline 21-26C, potrebno je cvrsto "
 "postolje."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Tiho"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Celicna ploca"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Zaustavi print"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Strogo"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Podrska"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Zamjenjeno"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "TERMALNA ANOMALIJA"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "TMC GRESKA DRAJVERA"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "TMC RESET DRAJVERA"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRAJVER SKRACEN"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC GRESKA PREGRIJAN"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC NISKA VOLTAZA"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2110,27 +2114,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Toplinski model još nije kalibriran."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Temperature"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Testiram filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2138,7 +2142,7 @@ msgstr ""
 "njegovo kretanje."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2146,7 +2150,7 @@ msgstr ""
 "sprjecava njegovo kretanje."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2156,7 +2160,7 @@ msgstr ""
 "optimalnu visinu. Provjerite slike u prirucniku (poglavlje Kalibracija)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2165,63 +2169,63 @@ msgstr ""
 "poglavlje Prvi koraci, odjeljak Tijek kalibracije."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Vrijeme"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Pauza"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Ukupno"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Totalne pogreske"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Totalno filamenta"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Vrijeme printanja"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Ugodi"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "ISPRAZNI RUCNO"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Prazni"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Ispraznite fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Praznjenje filamenta"
 
@@ -2238,23 +2242,23 @@ msgid "Unloading to pulley"
 msgstr "PRAZNJ DO REMENICE"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Provjera nije uspjela, uklonite filament i pokusajte ponovno."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Voltaza"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "UPOZORENJE TMC VRUC"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2266,200 +2270,194 @@ msgstr ""
 "u tihom modu"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Ceka se korisnik..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Ceka se hladenje PINDA sonde"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Ceka se hladjenje mlaznice i podloge"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Upozore"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Upozorenje: promijenjeni su i tip printera i tip maticne ploce."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Upozorenje: tip maticne ploce je promijenjen."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Upozorenje: promijenjena je vrsta printera."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Je li praznjenje fil. bilo uspjesno?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Greska u ozicenju"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Carobnjak"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "X-ispravan"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "XYZ detalji kal"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ kalibracija u redu. Iskrivljenost ce se automatski ispraviti."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ kalibracija je u redu. Osi X/Y su malo nagnute. Bravo!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "XYZ kalibracija je ugrozena. Prednje kalibracijske tocke nisu dostupne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ kalibracija je ugrozena. Desna prednja tocka kalibracije nije dostupna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "XYZ kalibracija nije uspjela. Tocka kalibracije podloga nije pronadena."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "XYZ kalibracija nije uspjela. Prednje kalibracijske tocke nisu dostupne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracija nije uspjela. Molimo pogledajte prirucnik."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "XYZ kalibracija nije uspjela. Desna prednja tocka kalibracije nije dostupna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ kalibracija u redu. Osi X/Y su okomite. Cestitamo!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Y distanca od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Y-ispravan"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Da"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Carobnjak uvijek mozete nastaviti iz Kalibracija -> Carobnjak."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Z-ispravan"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Z-sonda br."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] razmak tocke"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "i pritisnite gumb"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "da napuni filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "da isprazni filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "nepoznato"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "nepoznato stanje"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Osvjeziti"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "Neusp. MMU nap"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT IZBAČEN"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2468,12 +2466,12 @@ msgstr ""
 " senzore i ožičenje."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "NEUSPJEH PUNI EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2482,28 +2480,28 @@ msgstr ""
 "Poboljšajte kalibraciju senzora, ako je potrebno."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU GRESKA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Materijal razmjene"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Uklonite izbačenu nit s prednje strane MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2512,7 +2510,7 @@ msgstr ""
 "jedna nit nije u selektoru i da FINDA radi ispravno."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2520,55 +2518,47 @@ msgstr ""
 "3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Predpunjenje MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "MK3 firmware otkriven na MK3S printeru"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "MK3S firmware detektiran na MK3 printeru"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "NEPOZNATA POGREŠKA"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Došlo je do neočekivane pogreške."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Izbaciti"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "PROMJENA FILAMENTA"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Napunite"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Promjena filamenta M600. Stavite novu nit ili izbacite staru."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Osjetljivost"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Niveliranje podloge nije uspijelo. Pokrenite Z kalibraciju."
 
@@ -2582,10 +2572,19 @@ msgstr "Set spreman"
 msgid "Set not Ready"
 msgstr "Set nije spreman"
 
-#. MSG_REPRINT c=8
-#: ../../Firmware/ultralcd.cpp:5189
+#. MSG_REPRINT c=7
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Pretisak"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Osvjeziti"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "MK3 firmware otkriven na MK3S printeru"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "MK3S firmware detektiran na MK3 printeru"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Uklonite stari fil. i pritisnite gumb za pocetak stavljanja novog."

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2572,7 +2572,7 @@ msgstr "Set spreman"
 msgid "Set not Ready"
 msgstr "Set nije spreman"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Pretisak"

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 vagy regebbi"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 v. ujabb"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "Vart szint: %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Megsem"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Z allitasa"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Minden rendben"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Keszen vagyunk. Jo nyomtatast!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Abece"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Mindig"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Kornyezet"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "A Z tengely a felso vegponton van?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Seged"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Autom."
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Auto homeolas"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Auto ero"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "Fil. auto.betolt."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Autom. betoltes be, nyomd meg a gombot es helyzed be a filamentet."
@@ -112,52 +113,52 @@ msgid "Avoiding grind"
 msgstr "Daralas megelozese"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Tengely"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Tengely hossz"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Vissza"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Asztal"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Asztal futes"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Asztal kesz"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Szint. korrekcio"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,54 +167,54 @@ msgstr ""
 " az ujrainditast."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Asztal/Fej futes"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Szij allapot"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Szij teszt"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Aramkieses volt, nyomt. folytatasa?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Fenyes"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Fenyero"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "KOMUNIKACIOS HIBA"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "XYZ kalibracio"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Z kalibracio"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +223,13 @@ msgstr ""
 "nem er, majd nyomd meg ha keszen vagy."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Z kalibralasa"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,156 +238,156 @@ msgstr ""
 "er, majd nyomd meg ha keszen vagy."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Home poz. kalibralas"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Kalibracio"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Kalibracio kesz"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Nem tudom mozgatni a Fejet vagy a Gorgot"
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "A muvelet nem hajthato vegre, a filament mar be van toltve. Vedd ki elobb."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "Kartya eltavolitva"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Cserelj SD kartyat"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Filament csere"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Csere sikerult!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Sikerult a csere?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "X tengely ellenorzes"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Y tengely ellenorzes"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Z tengely ellenorzes"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Asztal ellenorzese"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Vegallaskapcs. ellen"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Fajl ellenorzese"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Hotend ellenorzese"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Szenz. ellenorzese"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Ellenorzesek"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "TM hiba törlése"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Szin nem jo"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Kozossegi"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Folyt"
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Lehutes"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Kivalasztott nyelv masolasa?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Utkozes"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Utkozes erz."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Utkozes erzekelve."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -397,34 +398,34 @@ msgstr ""
 "kapcsolhato be"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Filament vagasa"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Vago"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Sotet"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Letilt"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Motorok kikapcsol."
 
@@ -436,8 +437,8 @@ msgid "Disengaging idler"
 msgstr "Gorgo levalasztasa"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -448,7 +449,7 @@ msgstr ""
 " bekezdest."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -456,14 +457,14 @@ msgstr ""
 "Meg szeretned ismetelni az utolso lepest, hogy finomhangold a fuvoka es az "
 "asztal kozotti tavolsagot?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Kesz"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "E-korrekcio"
 
@@ -492,13 +493,13 @@ msgid "ERR Wait for User"
 msgstr "Felh. varakozas HIBA"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "HIBA:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Kiadás az MMUból"
 
@@ -510,17 +511,17 @@ msgid "Ejecting filament"
 msgstr "Filament kiadasa"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Vegallaskapcsolo"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Vegallask. nem kapcs"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Vegallaskapcsolok"
 
@@ -532,45 +533,45 @@ msgid "Engaging idler"
 msgstr "Gorgo becsatolasa"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "F. autobetolt"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "Dugul. eszlel"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "F. fogyas"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT MAR BENT"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NEM KAPCSOLT"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -579,7 +580,7 @@ msgstr ""
 "fil. utjat es a FINDA mukodeset."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -588,65 +589,65 @@ msgstr ""
 " FINDA mukodeset."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FIL. SZORULT"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "FSz akcio"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSZENZOR NEM KAPCSOL"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSZENZ. TUL HAMAR"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSZENZOR: F SZORULT"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "FW FUTAS HIBA"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Hiba statisztika"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "MMU hiba stat."
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Hamis kivalto ok"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Vent. sebesseg"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Ventillator teszt"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Vent.proba"
 
@@ -675,46 +676,46 @@ msgid "Feeding to nozzle"
 msgstr "Fuvokahoz toltes"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Fil. kifutasok"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Fil. szenzor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Filament es a szine rendben?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Fil. nincs betoltve"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Filament szenzor"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -723,7 +724,7 @@ msgstr ""
 "filament utjat es a szenort."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -732,7 +733,7 @@ msgstr ""
 " filament utjat es a szenort."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -741,42 +742,42 @@ msgstr ""
 "Ellenorizd a PTFE csovet es a szenzort."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Felhasznalt filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "A fajl vege hianyzik. Folytatod igy is?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Mozdulat befejezese"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Elso reteg kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Elsokent lefuttatom az onellenorzest, hogy megnezzem a leggyakoribb "
 "osszeszerelesi problemakat."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Flow"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -785,28 +786,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Elso targyhuto vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Elulso old[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Elso/bal ventillator"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "A G-kod mas szintre lett elokesztve. Folytassam?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -815,14 +816,14 @@ msgstr ""
 "megallitva."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "A G-kod mas nyomtato tipusra lett elokesztve.Folytassam?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -831,12 +832,12 @@ msgstr ""
 "Nyomtatas megallitva."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "A G-kod ujabb firmverre lett elokesztve.Folytassam?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -845,35 +846,35 @@ msgstr ""
 "Nyomtatas megallitva."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "HW beallitas"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Futotest/Termisztor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Futes folyamatban"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "A bizonsagi idozito leallitotta a futest"
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Futes kesz."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -884,7 +885,7 @@ msgstr ""
 "nyomtathatsz is."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -893,8 +894,8 @@ msgstr ""
 " a beallitasi folyamaton?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Magas ero"
 
@@ -905,48 +906,48 @@ msgid "Homing"
 msgstr "Homeolas"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "A hotend 280C-os! Fuvoka kicserleve es kelloen meghuzva?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Hotend vent.:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Lefuttatom az XYZ kalibraciot. Ez akár 24 percig is eltarthat."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Lefuttatom a Z kalibraciot."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "GORGO NEM MOZOG"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "GORGO NEM MOZOG"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "ELLENŐRIZZE A FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "HELYTELEN SZERSZAM"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -955,27 +956,27 @@ msgstr ""
 "Acellapok menupont alatt."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Bed kalibracio pontositasa"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Info kepernyo"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "SD kartya inic."
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Helyezd be a filam."
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -984,279 +985,281 @@ msgstr ""
 "gombot."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Futas kozbeni hiba. Inditsd ujra az MMU-t vagy frissitsd a firmwaret."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Filament behelyezve?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Rajta van az acellap a targyasztalon?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteracio"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Utolso nyomtatas"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Utolso nyomt. hibak"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Bal"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Bal hotend vent.?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Bal [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Fenyes szint"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Sotet szint"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Lin. korrekcio"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Z magassag beall."
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Ossz.bet"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Filament betolt."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Betolt. fuvokahoz"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Betöltési teszt"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Szin tisztitasa"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Filament betoltese"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Laza szijtarcsa"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Hangos"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW FRISSIT. KELL"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware hiba, kerlek inditsd ujra az MMU-t"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NEM VALASZOL"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Ujra: Homerseklet visszaallitasa"
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST HIBA"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "MMU hibak"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "MMU bet. hibak"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr ""
 "Az MMU helytelenul valaszol. Nezd meg a kabelezest es a konnektorokat."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "Az MMU nem valaszol. Nezd meg a kabelezest es a konnektorokat."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU csatlakozott"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Magnes komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Fomenu"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Meroleg. hiba"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Kalibracios pont magassaganak merese"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Halo"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Asztal szintezes"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Modvaltas folyamatban..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Tovabbi reszletek a neten."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "X mozgatasa"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Y mozgatasa"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Z mozgatasa"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Tengely mozgatasa"
 
@@ -1267,95 +1270,96 @@ msgid "Moving selector"
 msgstr "Szelektor mozgatasa"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Uj firmver verzio erheto el:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Nem"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Nincs SD kartya"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Nincs mozgas."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Nincs"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Nincs csatlakoztatva"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Nem forog"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Most beallitjuk a fuvoka hegye es a targyasztal felulete kozotti tavolsagot."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Felfutom a fuvokat PLA-hoz."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Vedd le a tesztnyomatot az acellaprol."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Fuvoka"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Fuvoka csereand"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Fuv. atm."
 
@@ -1366,88 +1370,88 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Ki"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Regi beallitasokat talaltam. Az alap PID, Esteps, stb. lesz beallitva."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "Be"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "Egyszer"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "SZUNET HOMERSEK.HIBA"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "PID kalibracio"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "PID kal. kesz"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "PID kalibracio"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "PINDA Futes"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibracio sikertelen."
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr "PINDA kalibracio sikeres es aktiv. A Beallitasok ->PINDA kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "GORGO NEM MOZOG"
 
@@ -1458,13 +1462,13 @@ msgid "Parking selector"
 msgstr "Szelektor parkolasa"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Szun."
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Nyomtatas szunet"
 
@@ -1475,7 +1479,7 @@ msgid "Performing cut"
 msgstr "Filament vagas"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1484,7 +1488,7 @@ msgstr ""
 " fuvoka hozzaer a papirlaphoz, azonnal kapcsold ki a nyomtatot."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1493,29 +1497,29 @@ msgstr ""
 "folytathatod az uzembe helyezest a nyomtato ujrainditasaval."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Nezd meg az IR szenzor csatlakoz., vedd ki a filam., ha bent van."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Kerlek ellenorizd:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Kerlek, tisztisd le a targyasztalt, majd nyomd meg a gombot."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 "Kerlek, tisztisd meg a fuvokat kalibracio elott. Nyomd meg a gombot, ha "
 "keszen vagy."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1523,7 +1527,7 @@ msgstr ""
 "betolteshez."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1532,105 +1536,105 @@ msgstr ""
 "a betolteshez."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Kerlek eloszor toltsd be a filamentet."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr ""
 "Kerlek, nyisd ki a nyomogorgo ajtajat, es tavolitsd el a filamentet kezzel."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Kerlek, helyzed az acellapot a targyasztalra."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Kerlek, nyomd meg a gombot a filament kiadasahoz"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Kerlek, huzd ki a filamentet most"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Tavolitsd el a szallitasi segedanyagokat."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Kerlek, tavolisd el az acellapot az asztalrol."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Kerlek, elobb futtasd le az XYZ kalibraciot."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Kerlek eloszor vedd ki a filamentet, majd probalkozz ujra."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Kerlek frissits."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Kerlek varj"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Aramkimaradasok"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Elofutes"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Futsd fel a fuvokat!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Fuvoka futese folyamatban. Kerlek, varj."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Melegites vagashoz"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Melegites kiadashoz"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Felfutes betolteshez"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Felfutes kiadashoz"
 
@@ -1641,48 +1645,48 @@ msgid "Preparing blade"
 msgstr "Penge elokeszites"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Nyomd meg a gombot"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Nyomd meg a gombot a folytatashoz es a fuvoka felfutesehez."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Nyomt. megszakitva"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Targyhuto:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Nyomtatas SD-rol"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Nyomt. szuneteltetve"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Nyomtatasi ido"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Nyomtato IP cime:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1691,12 +1695,12 @@ msgstr ""
 "lepesek fejezetenek Kalibracio menete bekezdeset."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "A fuvoka atmeroje elter a G-kodtol. Folytasasm?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1705,7 +1709,7 @@ msgstr ""
 "beallitasokban. Nyomtatas megallitva."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr "Gorgo motor nem mozog. Ellenorizd hogy tud-e mozogni es a kabelezest."
 
@@ -1716,32 +1720,32 @@ msgid "Pushing filament"
 msgstr "Filament benyomasa"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "SOR TELE"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Hatso old.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Nyomt. visszaallit"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Atnevezes"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1750,24 +1754,24 @@ msgstr ""
 "kivuli ertekeket a G kodban."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Ujrainditas"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "XYZ kal. nullazas"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Nyomt. folytatasa"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Nyomtatas folytatasa"
 
@@ -1778,7 +1782,7 @@ msgid "Retract from FINDA"
 msgstr "FINDAtol visszahuz"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Ujra"
 
@@ -1789,17 +1793,17 @@ msgid "Returning selector"
 msgstr "Szelektor vissza"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Jobb"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Jobb old.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1808,66 +1812,66 @@ msgstr ""
 "fog mindent kezdeni. Folytatod?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "SDkartya"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "SZELEKTOR NEM HOMEOL"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SZELEKTOR NEM MOZOG"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "MEGALLITVA."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Kalibracios pont keresese az asztalon"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Kivalasztas"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Valassz egy filamentet az elso reteg kalibraciojahoz a menubol."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Valassz filamentet:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Valassz nyelvet"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Valaszd ki a fuvoka homersekletet, amelyik megfelel az altalad hasznalt "
 "anyaghoz ajanlott homersekletnek."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Valassz homersekletet, ami megfelel a filamenthez."
 
@@ -1878,73 +1882,73 @@ msgid "Selecting fil. slot"
 msgstr "Fil.poz.kivalasztasa"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Ondiagnosztika OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Ondiagnosztika indul"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Ondiagnosztika"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Ondiagnosztika hiba!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Ondiag. sikertelen"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "A pontos szenzor nelkuli homing erdekeben lefuttatom az ondiagnosztikat."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Szenzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Szenzor OK, vedd ki a filamentet most."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Homerseklet beall.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Beallitasok"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "NagyMerol.hiba"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Acellap"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1957,23 +1961,23 @@ msgstr ""
 "%cUjrainditas"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Vegallaskapcsolok"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Halk"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Kis merol.hiba"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1982,125 +1986,125 @@ msgstr ""
 "konyvtaron belul."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Hiba tortent, Z szintezes indul..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Rendez"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Fajlok rendezese"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Hang"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Sebesseg"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Forog"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabil 21-26C homerseklet es egy merev allvany (asztal) szukseges."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statisztika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Halk"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Acellapok"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Allj"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Nyomt. megallitasa"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Szigoru"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Tamogatas"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Felcserelve"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "Homersekl. anomalia"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "TMC DRIVER HIBA"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "TMC DRIVER RESZET"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRIVER ZARLAT"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC TULHEVULES HIBA"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC ALACSONY FESZ."
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2109,27 +2113,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "A termikus modell még nincs kalibrálva."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Homerseklet"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Homersekletek"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Filament tesztelese"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2137,7 +2141,7 @@ msgstr ""
 "mozgasat."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2145,7 +2149,7 @@ msgstr ""
 "mozgasat."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2156,7 +2160,7 @@ msgstr ""
 "Kalibracio fejezeteben."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2165,63 +2169,63 @@ msgstr ""
 " fejezetenek Kalibracio menete bekezdeset."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Ido"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Idotullepes"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Ossz."
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Ossz. hiba"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Osszes filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Ossz. nyomt. ido"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Hangolás"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "VEDD KI KEZZEL"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Kiadas"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Filament kiadasa"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Filament kiadasa"
 
@@ -2238,23 +2242,23 @@ msgid "Unloading to pulley"
 msgstr "Kiadas a gorgohoz"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Ellenorzes sikertelen, vedd ki a filamentet es probald ujra."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Feszultsegek"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "FIGYELEM A TMC FORRO"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2267,203 +2271,197 @@ msgstr ""
 "Halk modban"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Var. a felhasznalora"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "A PINDA szenzor kihuleset varom."
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "A fuvoka es az asztal kihuleset varom."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Figylem."
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Figyelem: a nyomtato es az alaplap tipusa is megvaltozott."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Figyelem: az alaplap tipusa megvaltozott."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Figyelem: a nyomtato tipusa megvaltozott."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Sikerult kivenni a filamentet?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Kabelezesi hiba"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Varazslo"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "X-korrekcio"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "XYZ kal. reszlet"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "XYZ kalibracio OK. Az esetleges X/Y merolegessegi hiba automatikusan "
 "korrigalva lesz."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "XYZ kalibracio sikerult. Az X/Y tengelyeken enyhe merolegessegi hiba van."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az elulso kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. A jobb kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az asztal kalibracios pontja nem erheto el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az elulso kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracio sikertelen. Kerlek, nezz bele a kezikonyvbe."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. A jobb kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ kalibracio OK. Az X/Y tengelyek merolegesek. Gratulalok!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Y-minimum tavolsag"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Y-korrekcio"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Igen"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "A Varazsolt barmikor elered a Kalibracio -> Varazslo menubol."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Z-korrekcio"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Z meres szama"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] pont offszet"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "es nyomd meg a gombot"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "filam. betoltesehez"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "filament kiadasahoz"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "ismeretlen"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "ismeretlen allapot"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Frissites"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "MMU tap hibak"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT KIADVA"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2472,12 +2470,12 @@ msgstr ""
 "betöltve. Ellenőrizze az érzékelőket és a vezetékeket."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "BETÖLTÉS SIKERTELEN"
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2486,28 +2484,28 @@ msgstr ""
 "alakját. Ha szükséges, finomítsd az érzékelő kalibrálását."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU HIBA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Anyagcserék"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Távolítsd el a kiadott filamentet az MMU-ból."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2516,7 +2514,7 @@ msgstr ""
 "arról,hogy nincs fil. a szelektorban, és a FINDA megfelelően működik."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2524,56 +2522,48 @@ msgstr ""
 "3.0.1-es verzióra."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Betöltés az MMUba"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "MK3 firmver telepitve MK3S nyomtatora"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "MK3S firmver eszlelve MK3 nyomtaton"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "ISMERETLEN HIBA"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Váratlan hiba történt."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Kiadás"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "FILAMENT CSERE"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Betöltés"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "M600 Filamentcsere. Helyezz be egy új filamentet, vagy vedd ki a régit."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Érzékenység"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Sikertelen asztal szintezés. Kérjük, futtasd a Z kalibrálást."
 
@@ -2588,9 +2578,18 @@ msgid "Set not Ready"
 msgstr "Készen nem áll"
 
 #. MSG_REPRINT c=7
-#: ../../Firmware/ultralcd.cpp:5189
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Reprint"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Frissites"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "MK3 firmver telepitve MK3S nyomtatora"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "MK3S firmver eszlelve MK3 nyomtaton"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2587,6 +2587,11 @@ msgstr "Készen áll"
 msgid "Set not Ready"
 msgstr "Készen nem áll"
 
+#. MSG_REPRINT c=7
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Reprint"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."
 

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 vagy regebbi"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 v. ujabb"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "Vart szint: %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Megsem"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Z allitasa"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Minden rendben"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Keszen vagyunk. Jo nyomtatast!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Abece"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Mindig"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Kornyezet"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "A Z tengely a felso vegponton van?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Seged"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Autom."
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Auto homeolas"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Auto ero"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "Fil. auto.betolt."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Autom. betoltes be, nyomd meg a gombot es helyzed be a filamentet."
@@ -113,52 +112,52 @@ msgid "Avoiding grind"
 msgstr "Daralas megelozese"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Tengely"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Tengely hossz"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Vissza"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Asztal"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Asztal futes"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Asztal kesz"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Szint. korrekcio"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +166,54 @@ msgstr ""
 " az ujrainditast."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Asztal/Fej futes"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Szij allapot"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Szij teszt"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Aramkieses volt, nyomt. folytatasa?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Fenyes"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Fenyero"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "KOMUNIKACIOS HIBA"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "XYZ kalibracio"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Z kalibracio"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +222,13 @@ msgstr ""
 "nem er, majd nyomd meg ha keszen vagy."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Z kalibralasa"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,156 +237,156 @@ msgstr ""
 "er, majd nyomd meg ha keszen vagy."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Home poz. kalibralas"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Kalibracio"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Kalibracio kesz"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Nem tudom mozgatni a Fejet vagy a Gorgot"
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "A muvelet nem hajthato vegre, a filament mar be van toltve. Vedd ki elobb."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "Kartya eltavolitva"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Cserelj SD kartyat"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Filament csere"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Csere sikerult!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Sikerult a csere?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "X tengely ellenorzes"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Y tengely ellenorzes"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Z tengely ellenorzes"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Asztal ellenorzese"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Vegallaskapcs. ellen"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Fajl ellenorzese"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Hotend ellenorzese"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Szenz. ellenorzese"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Ellenorzesek"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "TM hiba törlése"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Szin nem jo"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Kozossegi"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Folyt"
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Lehutes"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Kivalasztott nyelv masolasa?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Utkozes"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Utkozes erz."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Utkozes erzekelve."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -398,34 +397,34 @@ msgstr ""
 "kapcsolhato be"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Filament vagasa"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Vago"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Sotet"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Letilt"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Motorok kikapcsol."
 
@@ -437,8 +436,8 @@ msgid "Disengaging idler"
 msgstr "Gorgo levalasztasa"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -449,7 +448,7 @@ msgstr ""
 " bekezdest."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -457,14 +456,14 @@ msgstr ""
 "Meg szeretned ismetelni az utolso lepest, hogy finomhangold a fuvoka es az "
 "asztal kozotti tavolsagot?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Kesz"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "E-korrekcio"
 
@@ -493,13 +492,13 @@ msgid "ERR Wait for User"
 msgstr "Felh. varakozas HIBA"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "HIBA:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Kiadás az MMUból"
 
@@ -511,17 +510,17 @@ msgid "Ejecting filament"
 msgstr "Filament kiadasa"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Vegallaskapcsolo"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Vegallask. nem kapcs"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Vegallaskapcsolok"
 
@@ -533,45 +532,45 @@ msgid "Engaging idler"
 msgstr "Gorgo becsatolasa"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "F. autobetolt"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "Dugul. eszlel"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "F. fogyas"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT MAR BENT"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NEM KAPCSOLT"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -580,7 +579,7 @@ msgstr ""
 "fil. utjat es a FINDA mukodeset."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -589,65 +588,65 @@ msgstr ""
 " FINDA mukodeset."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FIL. SZORULT"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "FSz akcio"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSZENZOR NEM KAPCSOL"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSZENZ. TUL HAMAR"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSZENZOR: F SZORULT"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "FW FUTAS HIBA"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Hiba statisztika"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "MMU hiba stat."
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Hamis kivalto ok"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Vent. sebesseg"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Ventillator teszt"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Vent.proba"
 
@@ -676,46 +675,46 @@ msgid "Feeding to nozzle"
 msgstr "Fuvokahoz toltes"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Fil. kifutasok"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Fil. szenzor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Filament es a szine rendben?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Fil. nincs betoltve"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Filament szenzor"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -724,7 +723,7 @@ msgstr ""
 "filament utjat es a szenort."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -733,7 +732,7 @@ msgstr ""
 " filament utjat es a szenort."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -742,42 +741,42 @@ msgstr ""
 "Ellenorizd a PTFE csovet es a szenzort."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Felhasznalt filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "A fajl vege hianyzik. Folytatod igy is?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Mozdulat befejezese"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Elso reteg kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Elsokent lefuttatom az onellenorzest, hogy megnezzem a leggyakoribb "
 "osszeszerelesi problemakat."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Flow"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -786,28 +785,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Elso targyhuto vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Elulso old[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Elso/bal ventillator"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "A G-kod mas szintre lett elokesztve. Folytassam?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -816,14 +815,14 @@ msgstr ""
 "megallitva."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "A G-kod mas nyomtato tipusra lett elokesztve.Folytassam?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -832,12 +831,12 @@ msgstr ""
 "Nyomtatas megallitva."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "A G-kod ujabb firmverre lett elokesztve.Folytassam?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -846,35 +845,35 @@ msgstr ""
 "Nyomtatas megallitva."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "HW beallitas"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Futotest/Termisztor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Futes folyamatban"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "A bizonsagi idozito leallitotta a futest"
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Futes kesz."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -885,7 +884,7 @@ msgstr ""
 "nyomtathatsz is."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -894,8 +893,8 @@ msgstr ""
 " a beallitasi folyamaton?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Magas ero"
 
@@ -906,48 +905,48 @@ msgid "Homing"
 msgstr "Homeolas"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "A hotend 280C-os! Fuvoka kicserleve es kelloen meghuzva?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Hotend vent.:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Lefuttatom az XYZ kalibraciot. Ez akár 24 percig is eltarthat."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Lefuttatom a Z kalibraciot."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "GORGO NEM MOZOG"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "GORGO NEM MOZOG"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "ELLENŐRIZZE A FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "HELYTELEN SZERSZAM"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -956,27 +955,27 @@ msgstr ""
 "Acellapok menupont alatt."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Bed kalibracio pontositasa"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Info kepernyo"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "SD kartya inic."
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Helyezd be a filam."
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -985,281 +984,279 @@ msgstr ""
 "gombot."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Futas kozbeni hiba. Inditsd ujra az MMU-t vagy frissitsd a firmwaret."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Filament behelyezve?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Rajta van az acellap a targyasztalon?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Iteracio"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Utolso nyomtatas"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Utolso nyomt. hibak"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Bal"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Bal hotend vent.?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Bal [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Fenyes szint"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Sotet szint"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Lin. korrekcio"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Z magassag beall."
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Ossz.bet"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Filament betolt."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Betolt. fuvokahoz"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Betöltési teszt"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Szin tisztitasa"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Filament betoltese"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Laza szijtarcsa"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Hangos"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW FRISSIT. KELL"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware hiba, kerlek inditsd ujra az MMU-t"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NEM VALASZOL"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Ujra: Homerseklet visszaallitasa"
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST HIBA"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "MMU hibak"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "MMU bet. hibak"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr ""
 "Az MMU helytelenul valaszol. Nezd meg a kabelezest es a konnektorokat."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "Az MMU nem valaszol. Nezd meg a kabelezest es a konnektorokat."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU csatlakozott"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Magnes komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Fomenu"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Meroleg. hiba"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Kalibracios pont magassaganak merese"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Halo"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Asztal szintezes"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Modvaltas folyamatban..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Tovabbi reszletek a neten."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "X mozgatasa"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Y mozgatasa"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Z mozgatasa"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Tengely mozgatasa"
 
@@ -1270,96 +1267,95 @@ msgid "Moving selector"
 msgstr "Szelektor mozgatasa"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Uj firmver verzio erheto el:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Nem"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Nincs SD kartya"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Nincs mozgas."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Nincs"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Nincs csatlakoztatva"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Nem forog"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Most beallitjuk a fuvoka hegye es a targyasztal felulete kozotti tavolsagot."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Felfutom a fuvokat PLA-hoz."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Vedd le a tesztnyomatot az acellaprol."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Fuvoka"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Fuvoka csereand"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Fuv. atm."
 
@@ -1370,88 +1366,88 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Ki"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Regi beallitasokat talaltam. Az alap PID, Esteps, stb. lesz beallitva."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "Be"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "Egyszer"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "SZUNET HOMERSEK.HIBA"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "PID kalibracio"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "PID kal. kesz"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "PID kalibracio"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "PINDA Futes"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibracio sikertelen."
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr "PINDA kalibracio sikeres es aktiv. A Beallitasok ->PINDA kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "GORGO NEM MOZOG"
 
@@ -1462,13 +1458,13 @@ msgid "Parking selector"
 msgstr "Szelektor parkolasa"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Szun."
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Nyomtatas szunet"
 
@@ -1479,7 +1475,7 @@ msgid "Performing cut"
 msgstr "Filament vagas"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1488,7 +1484,7 @@ msgstr ""
 " fuvoka hozzaer a papirlaphoz, azonnal kapcsold ki a nyomtatot."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1497,29 +1493,29 @@ msgstr ""
 "folytathatod az uzembe helyezest a nyomtato ujrainditasaval."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Nezd meg az IR szenzor csatlakoz., vedd ki a filam., ha bent van."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Kerlek ellenorizd:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Kerlek, tisztisd le a targyasztalt, majd nyomd meg a gombot."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 "Kerlek, tisztisd meg a fuvokat kalibracio elott. Nyomd meg a gombot, ha "
 "keszen vagy."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1527,7 +1523,7 @@ msgstr ""
 "betolteshez."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1536,105 +1532,105 @@ msgstr ""
 "a betolteshez."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Kerlek eloszor toltsd be a filamentet."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr ""
 "Kerlek, nyisd ki a nyomogorgo ajtajat, es tavolitsd el a filamentet kezzel."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Kerlek, helyzed az acellapot a targyasztalra."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Kerlek, nyomd meg a gombot a filament kiadasahoz"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Kerlek, huzd ki a filamentet most"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Tavolitsd el a szallitasi segedanyagokat."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Kerlek, tavolisd el az acellapot az asztalrol."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Kerlek, elobb futtasd le az XYZ kalibraciot."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Kerlek eloszor vedd ki a filamentet, majd probalkozz ujra."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Kerlek frissits."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Kerlek varj"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Aramkimaradasok"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Elofutes"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Futsd fel a fuvokat!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Fuvoka futese folyamatban. Kerlek, varj."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Melegites vagashoz"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Melegites kiadashoz"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Felfutes betolteshez"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Felfutes kiadashoz"
 
@@ -1645,48 +1641,48 @@ msgid "Preparing blade"
 msgstr "Penge elokeszites"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Nyomd meg a gombot"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Nyomd meg a gombot a folytatashoz es a fuvoka felfutesehez."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Nyomt. megszakitva"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Targyhuto:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Nyomtatas SD-rol"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Nyomt. szuneteltetve"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Nyomtatasi ido"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Nyomtato IP cime:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1695,12 +1691,12 @@ msgstr ""
 "lepesek fejezetenek Kalibracio menete bekezdeset."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "A fuvoka atmeroje elter a G-kodtol. Folytasasm?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1709,7 +1705,7 @@ msgstr ""
 "beallitasokban. Nyomtatas megallitva."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr "Gorgo motor nem mozog. Ellenorizd hogy tud-e mozogni es a kabelezest."
 
@@ -1720,32 +1716,32 @@ msgid "Pushing filament"
 msgstr "Filament benyomasa"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "SOR TELE"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Hatso old.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Nyomt. visszaallit"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Atnevezes"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1754,24 +1750,24 @@ msgstr ""
 "kivuli ertekeket a G kodban."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Ujrainditas"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "XYZ kal. nullazas"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Nyomt. folytatasa"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Nyomtatas folytatasa"
 
@@ -1782,7 +1778,7 @@ msgid "Retract from FINDA"
 msgstr "FINDAtol visszahuz"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Ujra"
 
@@ -1793,17 +1789,17 @@ msgid "Returning selector"
 msgstr "Szelektor vissza"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Jobb"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Jobb old.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1812,66 +1808,66 @@ msgstr ""
 "fog mindent kezdeni. Folytatod?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "SDkartya"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "SZELEKTOR NEM HOMEOL"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SZELEKTOR NEM MOZOG"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "MEGALLITVA."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Kalibracios pont keresese az asztalon"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Kivalasztas"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Valassz egy filamentet az elso reteg kalibraciojahoz a menubol."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Valassz filamentet:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Valassz nyelvet"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Valaszd ki a fuvoka homersekletet, amelyik megfelel az altalad hasznalt "
 "anyaghoz ajanlott homersekletnek."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Valassz homersekletet, ami megfelel a filamenthez."
 
@@ -1882,73 +1878,73 @@ msgid "Selecting fil. slot"
 msgstr "Fil.poz.kivalasztasa"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Ondiagnosztika OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Ondiagnosztika indul"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Ondiagnosztika"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Ondiagnosztika hiba!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Ondiag. sikertelen"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "A pontos szenzor nelkuli homing erdekeben lefuttatom az ondiagnosztikat."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Szenzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Szenzor OK, vedd ki a filamentet most."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Homerseklet beall.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Beallitasok"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "NagyMerol.hiba"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Acellap"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1961,23 +1957,23 @@ msgstr ""
 "%cUjrainditas"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Vegallaskapcsolok"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Halk"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Kis merol.hiba"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1986,125 +1982,125 @@ msgstr ""
 "konyvtaron belul."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Hiba tortent, Z szintezes indul..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Rendez"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Fajlok rendezese"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Hang"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Sebesseg"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Forog"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabil 21-26C homerseklet es egy merev allvany (asztal) szukseges."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statisztika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Halk"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Acellapok"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Allj"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Nyomt. megallitasa"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Szigoru"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Tamogatas"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Felcserelve"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "Homersekl. anomalia"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "TMC DRIVER HIBA"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "TMC DRIVER RESZET"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRIVER ZARLAT"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC TULHEVULES HIBA"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC ALACSONY FESZ."
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2113,27 +2109,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "A termikus modell még nincs kalibrálva."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Homerseklet"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Homersekletek"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Filament tesztelese"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2141,7 +2137,7 @@ msgstr ""
 "mozgasat."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2149,7 +2145,7 @@ msgstr ""
 "mozgasat."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2160,7 +2156,7 @@ msgstr ""
 "Kalibracio fejezeteben."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2169,63 +2165,63 @@ msgstr ""
 " fejezetenek Kalibracio menete bekezdeset."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Ido"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Idotullepes"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Ossz."
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Ossz. hiba"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Osszes filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Ossz. nyomt. ido"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Hangolás"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "VEDD KI KEZZEL"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Kiadas"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Filament kiadasa"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Filament kiadasa"
 
@@ -2242,23 +2238,23 @@ msgid "Unloading to pulley"
 msgstr "Kiadas a gorgohoz"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Ellenorzes sikertelen, vedd ki a filamentet es probald ujra."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Feszultsegek"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "FIGYELEM A TMC FORRO"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2271,197 +2267,203 @@ msgstr ""
 "Halk modban"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Var. a felhasznalora"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "A PINDA szenzor kihuleset varom."
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "A fuvoka es az asztal kihuleset varom."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Figylem."
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Figyelem: a nyomtato es az alaplap tipusa is megvaltozott."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Figyelem: az alaplap tipusa megvaltozott."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Figyelem: a nyomtato tipusa megvaltozott."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Sikerult kivenni a filamentet?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Kabelezesi hiba"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Varazslo"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "X-korrekcio"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "XYZ kal. reszlet"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "XYZ kalibracio OK. Az esetleges X/Y merolegessegi hiba automatikusan "
 "korrigalva lesz."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "XYZ kalibracio sikerult. Az X/Y tengelyeken enyhe merolegessegi hiba van."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az elulso kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. A jobb kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az asztal kalibracios pontja nem erheto el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az elulso kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracio sikertelen. Kerlek, nezz bele a kezikonyvbe."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. A jobb kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ kalibracio OK. Az X/Y tengelyek merolegesek. Gratulalok!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Y-minimum tavolsag"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Y-korrekcio"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Igen"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "A Varazsolt barmikor elered a Kalibracio -> Varazslo menubol."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Z-korrekcio"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Z meres szama"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] pont offszet"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "es nyomd meg a gombot"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "filam. betoltesehez"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "filament kiadasahoz"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "ismeretlen"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "ismeretlen allapot"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Frissites"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "MMU tap hibak"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT KIADVA"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2470,12 +2472,12 @@ msgstr ""
 "betöltve. Ellenőrizze az érzékelőket és a vezetékeket."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "BETÖLTÉS SIKERTELEN"
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2484,28 +2486,28 @@ msgstr ""
 "alakját. Ha szükséges, finomítsd az érzékelő kalibrálását."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU HIBA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Anyagcserék"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Távolítsd el a kiadott filamentet az MMU-ból."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2514,7 +2516,7 @@ msgstr ""
 "arról,hogy nincs fil. a szelektorban, és a FINDA megfelelően működik."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2522,48 +2524,56 @@ msgstr ""
 "3.0.1-es verzióra."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Betöltés az MMUba"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "MK3 firmver telepitve MK3S nyomtatora"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "MK3S firmver eszlelve MK3 nyomtaton"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "ISMERETLEN HIBA"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Váratlan hiba történt."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Kiadás"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "FILAMENT CSERE"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Betöltés"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "M600 Filamentcsere. Helyezz be egy új filamentet, vagy vedd ki a régit."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Érzékenység"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Sikertelen asztal szintezés. Kérjük, futtasd a Z kalibrálást."
 
@@ -2580,16 +2590,7 @@ msgstr "Készen nem áll"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Reprint"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Frissites"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "MK3 firmver telepitve MK3S nyomtatora"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "MK3S firmver eszlelve MK3 nyomtaton"
+msgstr "Újranyomtatás"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2577,7 +2577,7 @@ msgstr "Készen áll"
 msgid "Set not Ready"
 msgstr "Készen nem áll"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Reprint"

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 o inferiore"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 o superiore"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "atteso livello %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Annulla"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Compensaz. Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Nessun errore"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Tutto fatto. Buona stampa!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Alfabeti"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Sempre"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Ambiente"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "I carrelli Z sin/des sono altezza max?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Trova origine"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Automatico"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "Autocaric. filam."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Evito triturazione"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Assi"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Lunghezza dell'asse"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Indietro"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Piano"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Riscald. piano"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Piano fatto."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Correz. liv.piano"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +168,54 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Piano/Riscald."
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Stato cinghie"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Test cinghie"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Blackout rilevato. Recuperare stampa?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Chiaro"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Luminosita'"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "ERRORE COMUNICAZIONE"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Calibra XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Calibra Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +224,13 @@ msgstr ""
 "all'altezza massima. Click per terminare."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,28 +239,28 @@ msgstr ""
 "all'altezza massima. Click per terminare."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Calibrazione Home"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Calibrazione"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Calibr. completa"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Impossibile spostare il Selettore o l'Idler"
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
@@ -267,128 +268,128 @@ msgstr ""
 "prima."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "SD rimossa"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Cambia scheda SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Cambia filamento"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Cambio riuscito!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Cambio corretto?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Verifica asse X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Verifica asse Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Verifica asse Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Verifica piano"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Verifica finecorsa"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Verifica file"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Verifica ugello"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Controllo sensori"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Controlli"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "Cancella errore TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Colore non puro"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Contribuiti"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Raffredda"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Copiare la lingua selezionata?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Impatto"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Rileva.crash"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Rilevato impatto."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -399,34 +400,34 @@ msgstr ""
 "in Modalita normale"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Taglia filamento"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Tagliatr."
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Scuro"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Disatt."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Disattiva motori"
 
@@ -438,8 +439,8 @@ msgid "Disengaging idler"
 msgstr "Distacco idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -449,7 +450,7 @@ msgstr ""
 "impostata. Seguire manuale, Primi Passi, Calibrazione primo strato."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -457,14 +458,14 @@ msgstr ""
 "Desideri ripetere l'ultimo passaggio per migliorare la distanza fra ugello e"
 " piatto?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Fatto"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "Correzione-E"
 
@@ -493,13 +494,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Attendere utente"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "ERRORE:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Espelli da MMU"
 
@@ -511,17 +512,17 @@ msgid "Ejecting filament"
 msgstr "Espellendo filamento"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Finecorsa"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Finec. fuori portata"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Finecorsa"
 
@@ -533,45 +534,45 @@ msgid "Engaging idler"
 msgstr "Ingaggio idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Estrusore"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Info estrusore"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "Autocar.fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "Ril. blocco"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "Ril. fine fil"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAM GIA CARICATO"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NON ATTIVATA"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -580,7 +581,7 @@ msgstr ""
 " che il fil. possa muoversi e che FINDA funzioni."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -589,65 +590,65 @@ msgstr ""
 "muoversi e che FINDA funzioni."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. BLOCC"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "Azione FS"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR NON ATTIVATO"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR IN ANTICIPO"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. BLOCC"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME ERROR"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Stat. fallimenti"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "Stat.fall. MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Falso innesco"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Velocita vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Test ventola"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Control.vent"
 
@@ -676,46 +677,46 @@ msgid "Feeding to nozzle"
 msgstr "Alim. in ugello"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Fil. esauriti"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Sensore fil."
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filamento"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Filamento estruso e con colore corretto?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Fil. non caricato"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Sensore filam."
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -724,7 +725,7 @@ msgstr ""
 "possa muoversi e che il sensore funzioni."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -733,7 +734,7 @@ msgstr ""
 "il filamento abbia raggiunto il sensore e che il sensore funzioni."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -743,42 +744,42 @@ msgstr ""
 "correttamente."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Fil. utilizzato"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "File incompleto. Continuare comunque?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Finaliz. spostamenti"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Cal. primo strato"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Per primo avviero l'autotest per controllare gli errori di assemblaggio piu "
 "comuni."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Flusso"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -787,28 +788,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Ventola frontale?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Fronte [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Ventola frontale/sin"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code processato per un livello diverso. Continuare?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -817,14 +818,14 @@ msgstr ""
 "slice del modello. Stampa annullata."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code processato per una stampante diversa. Continuare?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -833,12 +834,12 @@ msgstr ""
 "Annullamento stampa."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code processato per un FW piu recente. Continuare?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -847,35 +848,35 @@ msgstr ""
 "annullata."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "Impostazioni HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Riscald./Termist."
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Riscaldamento..."
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Riscaldamento fermato dal timer di sicurezza."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Riscald. completo"
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -886,7 +887,7 @@ msgstr ""
 "stampare."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -895,8 +896,8 @@ msgstr ""
 "processo di configurazione?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Forte"
 
@@ -907,48 +908,48 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend a 280C! Ugello cambiato e serrato secondo le specifiche?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Ventola hotend:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Adesso avviero una Calibrazione XYZ. Puo durare fino a 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Adesso avviero la Calibrazione Z."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "IDLER ERR. MOVIMENTO"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "IDLER BLOCCATO"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "ISPEZIONA FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "STRUM NON VAL"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -957,27 +958,27 @@ msgstr ""
 "Setup HW - Piastre in Acciaio."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Miglioramento punto di calibrazione del piatto"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Schermata info"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Inizial. scheda SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Inserire filamento"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -985,279 +986,281 @@ msgstr ""
 "Inserire filamento (senza caricarlo) nell'estrusore e premere la manopola."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
 "Errore runtime interno. Provare a resettare la MMU o ad aggiornare il FW."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Il filamento e' stato caricato?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Piastra d'acciaio su piano riscaldato?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iterazione"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Ultima stampa"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Errori ultima stampa"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Sinistra"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Vent SX hotend?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Sinistra [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Liv. Chiaro"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Liv. Scuro"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Correzione lineare"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Compensazione Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Carica tutti"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Carica filamento"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Carica ugello"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Prova di carica."
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Caricando colore"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Caricando filamento"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Puleggia lenta"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Forte"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "AGG FW MMU NECESSARI"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Errore interno FW MMU, resettare la MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "Mod. MMU"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NON RISPONDE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Riprova. Ripristino temperatura..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU AUTOTEST FALLITO"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "Fallimenti MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "Car MMU falliti"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU non risponde correttamente. Controlla cavi e connettori."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU non risponde. Controlla cavi e connettori."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU connessa"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Comp. Magneti"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Menu principale"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Dev. misurata"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Misura altezza di rif. del punto di calib."
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Griglia"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Liv. griglia piano"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Mod."
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Cambio modalita in corso..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Modello"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Piu dettagli online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motore"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Sposta X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Sposta Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Sposta Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Muovi asse"
 
@@ -1268,94 +1271,95 @@ msgid "Moving selector"
 msgstr "Muovo il selettore"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Nuova vers. FW disponibile:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "No"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Nessuna SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Nessun movimento."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Nessuno"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normale"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Non connesso"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Non gira"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Adesso calibro la distanza fra ugello e superfice del piatto."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Adesso preriscaldero l'ugello per PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Ora rimuovete la stampa di prova dalla piastra in acciaio."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Ugello"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Cambio dell'ugello"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Dia.Ugello"
 
@@ -1366,82 +1370,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Sono state trovate impostazioni vecchie. Verranno impostati i valori "
 "predefiniti di PID, Esteps etc."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "Singolo"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSA ERRORE TERMICO"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "Calibrazione PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "Calib. PID completa"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "Calibrazione PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "Riscaldamento PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "Calib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "Calibrazione temperatura fallita"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1450,7 +1454,7 @@ msgstr ""
 "Impostazioni ->Calib. PINDA"
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "PULEGGIA BLOCCATA"
 
@@ -1461,13 +1465,13 @@ msgid "Parking selector"
 msgstr "Posteggio selettore"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pausa"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Metti in pausa"
 
@@ -1478,7 +1482,7 @@ msgid "Performing cut"
 msgstr "Eseguo taglio"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1487,7 +1491,7 @@ msgstr ""
 "punti. In caso l'ugello muova il foglio spegnere subito la stampante."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1496,34 +1500,34 @@ msgstr ""
 "riprendi il Wizard."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Controllare il collegamento al sensore e rimuovere il filamento."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Verifica:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Pulisci il piatto, poi premi la manopola."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pulire l'ugello per la calibrazione, poi fare click."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Inserisci il filamento nell'estrusore, poi premi la manopola per caricarlo."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1532,104 +1536,104 @@ msgstr ""
 "caricarlo."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Carica il filamento, per favore."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Aprire la guida filam. e rimuovere il filam. a mano"
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Posizionate la piastra d'acciaio sul piano riscaldato."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Premete la manopola per scaricare il filamento"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Estrarre il filamento immediatamente"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Rimuovete i materiali da spedizione"
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Rimuovete la piastra di acciaio dal piano riscaldato"
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Esegui la calibrazione XYZ prima."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Scaricare prima il filamento, poi ripetere l'operazione."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Prego aggiornare."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Attendere"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Interr. corr."
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Preriscalda"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Prerisc. ugello!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Preriscaldando l'ugello. Attendere prego."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Preriscalda. taglio"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Preriscalda. espuls."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Preriscald. carico"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Preriscald. scarico"
 
@@ -1640,48 +1644,48 @@ msgid "Preparing blade"
 msgstr "Preparo la lama"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Premere la manopola"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Premete la manopola per preriscaldare l'ugello e continuare."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Stampa interrotta"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Vent.stam:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Stampa da SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Stampa in pausa"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Tempo di stampa"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Ind. IP stampante:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1690,12 +1694,12 @@ msgstr ""
 "Primi Passi."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diametro ugello diverso da G-Code. Continuare?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1704,7 +1708,7 @@ msgstr ""
 "Stampa annullata."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Il motore della puleggia è bloccato. Verifica che la puleggia possa muoversi"
@@ -1717,32 +1721,32 @@ msgid "Pushing filament"
 msgstr "Spingo il filamento"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "CODA PIENA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "Porta RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Retro [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Recupero stampa"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Rinomina"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1751,24 +1755,24 @@ msgstr ""
 "Controllare l'indice strumento nel G-code (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Reset calibr. XYZ."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Riprendi stampa"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Riprendi stampa"
 
@@ -1779,7 +1783,7 @@ msgid "Retract from FINDA"
 msgstr "Retrai da FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Riprova"
 
@@ -1790,17 +1794,17 @@ msgid "Returning selector"
 msgstr "Ritorno selettore"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Destra"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Destra [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1809,39 +1813,39 @@ msgstr ""
 "ricominciare dall'inizio. Continuare?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "Mem. SD"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELETTORE ERR MOVIM"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELETTORE BLOCCATO"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "ARRESTATO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Ricerca punti calibrazione piano"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Seleziona"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1850,27 +1854,27 @@ msgstr ""
 "menu sullo schermo."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Seleziona il filam.:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Seleziona lingua"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selezionate la temperatura per il preriscaldamento dell'ugello adatta al "
 "vostro materiale."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Seleziona la temperatura appropriata per il tuo materiale."
 
@@ -1881,72 +1885,72 @@ msgid "Selecting fil. slot"
 msgstr "Seleziono slot fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Autotest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Avvia autotest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Autotest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Errore Autotest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Autotest fallito"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Verra effettuato un self test per calibrare l'homing senza sensori"
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Info Sensore"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensore verificato, rimuovere il filamento."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Imposta temperatura:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Impostazioni"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Deviaz. forte"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Piano"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1959,23 +1963,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Stato finecorsa"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Silenz."
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Deviaz. lieve"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1984,126 +1988,126 @@ msgstr ""
 "e 100 perche siano ordinati."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Sono stati rilevati problemi, avviato livellamento Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Ordina"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Ordinando i file"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Suono"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Velocita"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Gira"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Sono necessari una temperatura ambiente di 21-26C e una superficie rigida."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statistiche"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Silenz."
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Piani d'acciaio"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Arresta stampa"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Esatto"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Supporto"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Scambiato"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIA TERMICA"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "ERRORE DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "RESET DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "CORTOCIRC TMC DRIVER"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "ERR TMC SURRISCALD"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERVOLTAGE ERR"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2112,27 +2116,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Modello termico non calibrato."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Temperature"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Provo il filamento"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2140,7 +2144,7 @@ msgstr ""
 "nulla che ne blocchi il movimento."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2148,7 +2152,7 @@ msgstr ""
 " sia nulla che ne blocchi il movimento."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2159,7 +2163,7 @@ msgstr ""
 "manuale (capitolo sulla calibrazione)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2168,63 +2172,63 @@ msgstr ""
 "Primi Passi - Sequenza di Calibrazione."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Cron."
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Totale"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Totale fallimenti"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Filamento totale"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Tempo stampa totale"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Regola"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "SCARICA MANUALMENTE"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Scarica"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Scarica filam."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Scaricando filamento"
 
@@ -2241,23 +2245,23 @@ msgid "Unloading to pulley"
 msgstr "Scarico in puleggia"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifica fallita, rimuovere il filamento e riprovare."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Voltaggi"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "ATTENZIONE TMC CALDO"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2270,201 +2274,195 @@ msgstr ""
 "Modalita silenziosa"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Attendendo utente..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "In attesa del raffreddamento della sonda PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "In attesa del raffreddamento dell'ugello e del piano"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Avviso"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Attenzione: tipo di stampante e di scheda madre cambiati."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Avviso: tipo di scheda madre cambiato"
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Avviso: tipo di stampante cambiato."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Filamento scaricato con successo?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Errore cablaggio"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "Correzione-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "XYZ Cal. dettagli"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Calibrazione XYZ corretta. La distorsione verra compensata automaticamente."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Calibrazione XYZ corretta. Assi X/Y leggermente storti. Ben fatto!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibrazione XYZ compromessa. Punti anteriori non raggiungibili."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "Calibrazione XYZ compromessa. Punto anteriore destro non raggiungibile."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibrazione XYZ fallita. Il punto di calibrazione sul piano non e' stato "
 "trovato."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibrazione XYZ fallita. Punti anteriori non raggiungibili."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrazione XYZ fallita. Consultare manuale."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibrazione XYZ fallita. Punto anteriore destro non raggiungibile."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibrazione XYZ OK. Gli assi X/Y sono perpendicolari. Complimenti!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Distanza Y dal min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Correzione-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Si"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "E possibile riprendere il Wizard in qualsiasi momento attraverso "
 "Calibrazione -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Correzione-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Nr. Z-test"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "e cliccare manopola"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "per caricare il fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "per scaricare fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "sconosciuto"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "stato sconosciuto"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Ricaricare"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "Manc. corr. MMU"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENTO ESPULSO"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2473,12 +2471,12 @@ msgstr ""
 "filamento. Controllare i sensori e il cablaggio."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "FALL CARICA SU EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2487,28 +2485,28 @@ msgstr ""
 "del fil. Affinare la calib. del sensore, se necessario."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "ERRORE MMU MCU"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Scambi materiali"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Rimuovere il filamento espulso dalla parte anteriore dell MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2517,7 +2515,7 @@ msgstr ""
 "nessun fil. sia nel selettore e che FINDA funzioni correttamente."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2525,56 +2523,48 @@ msgstr ""
 "stampante. Aggiornamento alla versione 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Precarica MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "Firmware MK3 rilevato su stampante MK3S"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "Firmware MK3S rilevato su stampante MK3"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "ERRORE SCONOSCIUTO"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Si è verificato un errore imprevisto."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Espelli"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "CAMBIO FILAMENTO"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Carica"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "Cambio filamento M600. Carica un nuovo filamento o espelli quello vecchio."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Sensibilità"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Livellamento piano fallito. Si prega di eseguire la calibrazione Z."
 
@@ -2588,10 +2578,19 @@ msgstr "Imposta pronta"
 msgid "Set not Ready"
 msgstr "Imposta non pronta"
 
-#. MSG_REPRINT c=10
-#: ../../Firmware/ultralcd.cpp:5189
+#. MSG_REPRINT c=7
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Ristampare"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Ricaricare"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "Firmware MK3 rilevato su stampante MK3S"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "Firmware MK3S rilevato su stampante MK3"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 o inferiore"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 o superiore"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "atteso livello %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Annulla"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Compensaz. Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Nessun errore"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Tutto fatto. Buona stampa!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Alfabeti"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Sempre"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Ambiente"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "I carrelli Z sin/des sono altezza max?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Trova origine"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Automatico"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "Autocaric. filam."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,52 +113,52 @@ msgid "Avoiding grind"
 msgstr "Evito triturazione"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Assi"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Lunghezza dell'asse"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Indietro"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Piano"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Riscald. piano"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Piano fatto."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Correz. liv.piano"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -168,54 +167,54 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Piano/Riscald."
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Stato cinghie"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Test cinghie"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Blackout rilevato. Recuperare stampa?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Chiaro"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Luminosita'"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "ERRORE COMUNICAZIONE"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Calibra XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Calibra Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -224,13 +223,13 @@ msgstr ""
 "all'altezza massima. Click per terminare."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -239,28 +238,28 @@ msgstr ""
 "all'altezza massima. Click per terminare."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Calibrazione Home"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Calibrazione"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Calibr. completa"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Impossibile spostare il Selettore o l'Idler"
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
@@ -268,128 +267,128 @@ msgstr ""
 "prima."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "SD rimossa"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Cambia scheda SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Cambia filamento"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Cambio riuscito!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Cambio corretto?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Verifica asse X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Verifica asse Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Verifica asse Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Verifica piano"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Verifica finecorsa"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Verifica file"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Verifica ugello"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Controllo sensori"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Controlli"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "Cancella errore TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Colore non puro"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Contribuiti"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Raffredda"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Copiare la lingua selezionata?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Impatto"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Rileva.crash"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Rilevato impatto."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -400,34 +399,34 @@ msgstr ""
 "in Modalita normale"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Taglia filamento"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Tagliatr."
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Scuro"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Disatt."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Disattiva motori"
 
@@ -439,8 +438,8 @@ msgid "Disengaging idler"
 msgstr "Distacco idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -450,7 +449,7 @@ msgstr ""
 "impostata. Seguire manuale, Primi Passi, Calibrazione primo strato."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -458,14 +457,14 @@ msgstr ""
 "Desideri ripetere l'ultimo passaggio per migliorare la distanza fra ugello e"
 " piatto?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Fatto"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "Correzione-E"
 
@@ -494,13 +493,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Attendere utente"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "ERRORE:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Espelli da MMU"
 
@@ -512,17 +511,17 @@ msgid "Ejecting filament"
 msgstr "Espellendo filamento"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Finecorsa"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Finec. fuori portata"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Finecorsa"
 
@@ -534,45 +533,45 @@ msgid "Engaging idler"
 msgstr "Ingaggio idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Estrusore"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Info estrusore"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "Autocar.fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "Ril. blocco"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "Ril. fine fil"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAM GIA CARICATO"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NON ATTIVATA"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -581,7 +580,7 @@ msgstr ""
 " che il fil. possa muoversi e che FINDA funzioni."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -590,65 +589,65 @@ msgstr ""
 "muoversi e che FINDA funzioni."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. BLOCC"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "Azione FS"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR NON ATTIVATO"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR IN ANTICIPO"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. BLOCC"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME ERROR"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Stat. fallimenti"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "Stat.fall. MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Falso innesco"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Velocita vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Test ventola"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Control.vent"
 
@@ -677,46 +676,46 @@ msgid "Feeding to nozzle"
 msgstr "Alim. in ugello"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Fil. esauriti"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Sensore fil."
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filamento"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Filamento estruso e con colore corretto?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Fil. non caricato"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Sensore filam."
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -725,7 +724,7 @@ msgstr ""
 "possa muoversi e che il sensore funzioni."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -734,7 +733,7 @@ msgstr ""
 "il filamento abbia raggiunto il sensore e che il sensore funzioni."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -744,42 +743,42 @@ msgstr ""
 "correttamente."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Fil. utilizzato"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "File incompleto. Continuare comunque?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Finaliz. spostamenti"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Cal. primo strato"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Per primo avviero l'autotest per controllare gli errori di assemblaggio piu "
 "comuni."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Flusso"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -788,28 +787,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Ventola frontale?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Fronte [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Ventola frontale/sin"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code processato per un livello diverso. Continuare?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -818,14 +817,14 @@ msgstr ""
 "slice del modello. Stampa annullata."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code processato per una stampante diversa. Continuare?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -834,12 +833,12 @@ msgstr ""
 "Annullamento stampa."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code processato per un FW piu recente. Continuare?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -848,35 +847,35 @@ msgstr ""
 "annullata."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "Impostazioni HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Riscald./Termist."
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Riscaldamento..."
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Riscaldamento fermato dal timer di sicurezza."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Riscald. completo"
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -887,7 +886,7 @@ msgstr ""
 "stampare."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -896,8 +895,8 @@ msgstr ""
 "processo di configurazione?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Forte"
 
@@ -908,48 +907,48 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend a 280C! Ugello cambiato e serrato secondo le specifiche?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Ventola hotend:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Adesso avviero una Calibrazione XYZ. Puo durare fino a 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Adesso avviero la Calibrazione Z."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "IDLER ERR. MOVIMENTO"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "IDLER BLOCCATO"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "ISPEZIONA FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "STRUM NON VAL"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -958,27 +957,27 @@ msgstr ""
 "Setup HW - Piastre in Acciaio."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Miglioramento punto di calibrazione del piatto"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Schermata info"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Inizial. scheda SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Inserire filamento"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -986,281 +985,279 @@ msgstr ""
 "Inserire filamento (senza caricarlo) nell'estrusore e premere la manopola."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
 "Errore runtime interno. Provare a resettare la MMU o ad aggiornare il FW."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Il filamento e' stato caricato?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Piastra d'acciaio su piano riscaldato?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Iterazione"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Ultima stampa"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Errori ultima stampa"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Sinistra"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Vent SX hotend?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Sinistra [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Liv. Chiaro"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Liv. Scuro"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Correzione lineare"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Compensazione Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Carica tutti"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Carica filamento"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Carica ugello"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Prova di carica."
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Caricando colore"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Caricando filamento"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Puleggia lenta"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Forte"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "AGG FW MMU NECESSARI"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Errore interno FW MMU, resettare la MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "Mod. MMU"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NON RISPONDE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Riprova. Ripristino temperatura..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU AUTOTEST FALLITO"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "Fallimenti MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "Car MMU falliti"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU non risponde correttamente. Controlla cavi e connettori."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU non risponde. Controlla cavi e connettori."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU connessa"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Comp. Magneti"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Menu principale"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Dev. misurata"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Misura altezza di rif. del punto di calib."
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Griglia"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Liv. griglia piano"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Mod."
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Cambio modalita in corso..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Modello"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Piu dettagli online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motore"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Sposta X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Sposta Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Sposta Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Muovi asse"
 
@@ -1271,95 +1268,94 @@ msgid "Moving selector"
 msgstr "Muovo il selettore"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Nuova vers. FW disponibile:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "No"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Nessuna SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Nessun movimento."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Nessuno"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normale"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Non connesso"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Non gira"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Adesso calibro la distanza fra ugello e superfice del piatto."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Adesso preriscaldero l'ugello per PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Ora rimuovete la stampa di prova dalla piastra in acciaio."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Ugello"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Cambio dell'ugello"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Dia.Ugello"
 
@@ -1370,82 +1366,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Sono state trovate impostazioni vecchie. Verranno impostati i valori "
 "predefiniti di PID, Esteps etc."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "Singolo"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSA ERRORE TERMICO"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "Calibrazione PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "Calib. PID completa"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "Calibrazione PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "Riscaldamento PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "Calib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "Calibrazione temperatura fallita"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1454,7 +1450,7 @@ msgstr ""
 "Impostazioni ->Calib. PINDA"
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "PULEGGIA BLOCCATA"
 
@@ -1465,13 +1461,13 @@ msgid "Parking selector"
 msgstr "Posteggio selettore"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pausa"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Metti in pausa"
 
@@ -1482,7 +1478,7 @@ msgid "Performing cut"
 msgstr "Eseguo taglio"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1491,7 +1487,7 @@ msgstr ""
 "punti. In caso l'ugello muova il foglio spegnere subito la stampante."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1500,34 +1496,34 @@ msgstr ""
 "riprendi il Wizard."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Controllare il collegamento al sensore e rimuovere il filamento."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Verifica:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Pulisci il piatto, poi premi la manopola."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pulire l'ugello per la calibrazione, poi fare click."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Inserisci il filamento nell'estrusore, poi premi la manopola per caricarlo."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1536,104 +1532,104 @@ msgstr ""
 "caricarlo."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Carica il filamento, per favore."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Aprire la guida filam. e rimuovere il filam. a mano"
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Posizionate la piastra d'acciaio sul piano riscaldato."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Premete la manopola per scaricare il filamento"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Estrarre il filamento immediatamente"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Rimuovete i materiali da spedizione"
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Rimuovete la piastra di acciaio dal piano riscaldato"
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Esegui la calibrazione XYZ prima."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Scaricare prima il filamento, poi ripetere l'operazione."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Prego aggiornare."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Attendere"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Interr. corr."
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Preriscalda"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Prerisc. ugello!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Preriscaldando l'ugello. Attendere prego."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Preriscalda. taglio"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Preriscalda. espuls."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Preriscald. carico"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Preriscald. scarico"
 
@@ -1644,48 +1640,48 @@ msgid "Preparing blade"
 msgstr "Preparo la lama"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Premere la manopola"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Premete la manopola per preriscaldare l'ugello e continuare."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Stampa interrotta"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Vent.stam:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Stampa da SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Stampa in pausa"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Tempo di stampa"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Ind. IP stampante:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1694,12 +1690,12 @@ msgstr ""
 "Primi Passi."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diametro ugello diverso da G-Code. Continuare?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1708,7 +1704,7 @@ msgstr ""
 "Stampa annullata."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Il motore della puleggia è bloccato. Verifica che la puleggia possa muoversi"
@@ -1721,32 +1717,32 @@ msgid "Pushing filament"
 msgstr "Spingo il filamento"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "CODA PIENA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "Porta RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Retro [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Recupero stampa"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Rinomina"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1755,24 +1751,24 @@ msgstr ""
 "Controllare l'indice strumento nel G-code (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Reset calibr. XYZ."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Riprendi stampa"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Riprendi stampa"
 
@@ -1783,7 +1779,7 @@ msgid "Retract from FINDA"
 msgstr "Retrai da FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Riprova"
 
@@ -1794,17 +1790,17 @@ msgid "Returning selector"
 msgstr "Ritorno selettore"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Destra"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Destra [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1813,39 +1809,39 @@ msgstr ""
 "ricominciare dall'inizio. Continuare?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "Mem. SD"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELETTORE ERR MOVIM"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELETTORE BLOCCATO"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "ARRESTATO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Ricerca punti calibrazione piano"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Seleziona"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1854,27 +1850,27 @@ msgstr ""
 "menu sullo schermo."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Seleziona il filam.:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Seleziona lingua"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selezionate la temperatura per il preriscaldamento dell'ugello adatta al "
 "vostro materiale."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Seleziona la temperatura appropriata per il tuo materiale."
 
@@ -1885,72 +1881,72 @@ msgid "Selecting fil. slot"
 msgstr "Seleziono slot fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Autotest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Avvia autotest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Autotest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Errore Autotest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Autotest fallito"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Verra effettuato un self test per calibrare l'homing senza sensori"
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Info Sensore"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensore verificato, rimuovere il filamento."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Imposta temperatura:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Impostazioni"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Deviaz. forte"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Piano"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1963,23 +1959,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Stato finecorsa"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Silenz."
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Deviaz. lieve"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1988,126 +1984,126 @@ msgstr ""
 "e 100 perche siano ordinati."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Sono stati rilevati problemi, avviato livellamento Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Ordina"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Ordinando i file"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Suono"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Velocita"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Gira"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Sono necessari una temperatura ambiente di 21-26C e una superficie rigida."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statistiche"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Silenz."
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Piani d'acciaio"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Arresta stampa"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Esatto"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Supporto"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Scambiato"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIA TERMICA"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "ERRORE DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "RESET DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "CORTOCIRC TMC DRIVER"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "ERR TMC SURRISCALD"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERVOLTAGE ERR"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2116,27 +2112,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Modello termico non calibrato."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Temperature"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Provo il filamento"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2144,7 +2140,7 @@ msgstr ""
 "nulla che ne blocchi il movimento."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2152,7 +2148,7 @@ msgstr ""
 " sia nulla che ne blocchi il movimento."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2163,7 +2159,7 @@ msgstr ""
 "manuale (capitolo sulla calibrazione)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2172,63 +2168,63 @@ msgstr ""
 "Primi Passi - Sequenza di Calibrazione."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Cron."
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Totale"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Totale fallimenti"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Filamento totale"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Tempo stampa totale"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Regola"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "SCARICA MANUALMENTE"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Scarica"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Scarica filam."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Scaricando filamento"
 
@@ -2245,23 +2241,23 @@ msgid "Unloading to pulley"
 msgstr "Scarico in puleggia"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifica fallita, rimuovere il filamento e riprovare."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Voltaggi"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "ATTENZIONE TMC CALDO"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2274,195 +2270,201 @@ msgstr ""
 "Modalita silenziosa"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Attendendo utente..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "In attesa del raffreddamento della sonda PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "In attesa del raffreddamento dell'ugello e del piano"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Avviso"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Attenzione: tipo di stampante e di scheda madre cambiati."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Avviso: tipo di scheda madre cambiato"
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Avviso: tipo di stampante cambiato."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Filamento scaricato con successo?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Errore cablaggio"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "Correzione-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "XYZ Cal. dettagli"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Calibrazione XYZ corretta. La distorsione verra compensata automaticamente."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Calibrazione XYZ corretta. Assi X/Y leggermente storti. Ben fatto!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibrazione XYZ compromessa. Punti anteriori non raggiungibili."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "Calibrazione XYZ compromessa. Punto anteriore destro non raggiungibile."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibrazione XYZ fallita. Il punto di calibrazione sul piano non e' stato "
 "trovato."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibrazione XYZ fallita. Punti anteriori non raggiungibili."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrazione XYZ fallita. Consultare manuale."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibrazione XYZ fallita. Punto anteriore destro non raggiungibile."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibrazione XYZ OK. Gli assi X/Y sono perpendicolari. Complimenti!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Distanza Y dal min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Correzione-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Si"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "E possibile riprendere il Wizard in qualsiasi momento attraverso "
 "Calibrazione -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Correzione-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Nr. Z-test"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "e cliccare manopola"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "per caricare il fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "per scaricare fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "sconosciuto"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "stato sconosciuto"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Ricaricare"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "Manc. corr. MMU"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENTO ESPULSO"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2471,12 +2473,12 @@ msgstr ""
 "filamento. Controllare i sensori e il cablaggio."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "FALL CARICA SU EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2485,28 +2487,28 @@ msgstr ""
 "del fil. Affinare la calib. del sensore, se necessario."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "ERRORE MMU MCU"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Scambi materiali"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Rimuovere il filamento espulso dalla parte anteriore dell MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2515,7 +2517,7 @@ msgstr ""
 "nessun fil. sia nel selettore e che FINDA funzioni correttamente."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2523,48 +2525,56 @@ msgstr ""
 "stampante. Aggiornamento alla versione 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Precarica MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "Firmware MK3 rilevato su stampante MK3S"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "Firmware MK3S rilevato su stampante MK3"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "ERRORE SCONOSCIUTO"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Si è verificato un errore imprevisto."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Espelli"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "CAMBIO FILAMENTO"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Carica"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "Cambio filamento M600. Carica un nuovo filamento o espelli quello vecchio."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Sensibilità"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Livellamento piano fallito. Si prega di eseguire la calibrazione Z."
 
@@ -2581,16 +2591,7 @@ msgstr "Imposta non pronta"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Ristampare"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Ricaricare"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "Firmware MK3 rilevato su stampante MK3S"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "Firmware MK3S rilevato su stampante MK3"
+msgstr "Ristampa"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2578,7 +2578,7 @@ msgstr "Imposta pronta"
 msgid "Set not Ready"
 msgstr "Imposta non pronta"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Ristampare"

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2588,6 +2588,11 @@ msgstr "Imposta pronta"
 msgid "Set not Ready"
 msgstr "Imposta non pronta"
 
+#. MSG_REPRINT c=10
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Ristampare"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."
 

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2590,6 +2590,11 @@ msgstr "Gereed zetten"
 msgid "Set not Ready"
 msgstr "Niet gereed zetten"
 
+#. MSG_REPRINT c=7
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Reprint"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Verwijder de oude filament en druk op de knop om nieuwe filament te laden."

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 of ouder"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 of nieuwer"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "%s niveau verwacht"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Annuleren"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Z aanpassen"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Allemaal goed"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Klaar. Happy printing!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Altijd"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Kamertemp."
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "Zijn beide Z wagen heelemaal boven?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Startpositie"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Auto power"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "Autoladen filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Slijpen vermijden"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "As"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Aslengte"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Terug"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Bed"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Bed opwarmen"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Bed klaar"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Bed niveau correct"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +168,54 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Bed/Verwarming"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Riem status"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Riemtest"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Stroomstoring. Print herstellen?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Helder"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Helderheid"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "COMMUNICATIEFOUT"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Kalibratie XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Kalibratie Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +224,13 @@ msgstr ""
 " stoppers. Druk knop als klaar."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Kalibreren Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,28 +239,28 @@ msgstr ""
 "stoppers. Druk knop als klaar."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Kalibreren start"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Kalibratie"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Kalibratie klaar"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Kan selector of spanrol niet bewegen."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
@@ -267,128 +268,128 @@ msgstr ""
 "uitladen."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "SD verwijderd"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Wissel SD kaart"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Wissel filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Wissel geslaagd!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Wissel ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Controleer X as"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Controleer Y as"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Controleer Z as"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Controleer bed"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Controleer endstops"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Bestand controle"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Controleer hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Controleer sensors"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Checks"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "TM-fout wissen"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Kleur niet juist"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Van de community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Door."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Afkoelen"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Geselecteerde taal kopiëren?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Crashdet."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Crash gedetecteerd."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -399,34 +400,34 @@ msgstr ""
 "gebruikt worden"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Fil. knippen"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Mes"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Dim"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Uitschak"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Motoren uit"
 
@@ -438,8 +439,8 @@ msgid "Disengaging idler"
 msgstr "Ontkoppel spanrol"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -450,7 +451,7 @@ msgstr ""
 "calibration."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -458,14 +459,14 @@ msgstr ""
 "Wilt u de laatste stap herhalen om de afstand tussen de tuit en de bed "
 "opnieuw in te stellen?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Klaar"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "E-correctie"
 
@@ -494,13 +495,13 @@ msgid "ERR Wait for User"
 msgstr "FOUT Wacht gebruiker"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "FOUT:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Uitwerp. van MMU"
 
@@ -512,17 +513,17 @@ msgid "Ejecting filament"
 msgstr "Fil. word ontladen"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Eindstop"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Endstop niet geraakt"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Eindstops"
 
@@ -534,45 +535,45 @@ msgid "Engaging idler"
 msgstr "Koppel spanrol"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "F. autoladen"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "F.Jam ontdek."
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "FS. uitloop"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT AL GELADEN"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA TRIGGERDE NIET"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -581,7 +582,7 @@ msgstr ""
 "ontladen. Controleer of Fil. kan bewegen en of de FINDA werkt."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -590,65 +591,65 @@ msgstr ""
 " kan bewegen en FINDA werkt."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA NIET FIL.VRIJ"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "FS actie"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSEN. NIET AF GEGAAN"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR TE VROEG"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. VAST"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME FOUT"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Foutstatistieken"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "MMU-Fouten"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Valse triggering"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Fan snelh."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Fan test"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Fans check"
 
@@ -677,46 +678,46 @@ msgid "Feeding to nozzle"
 msgstr "Voeding tot tuit"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Fil. fouten"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Fil. sensor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrudeert met de juiste kleur?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Fil. niet geladen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -725,7 +726,7 @@ msgstr ""
 "Controleer of het filament kan bewegen en de sensor werkt."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -734,7 +735,7 @@ msgstr ""
 "Controleer of het filament de fsensor heeft bereikt en de sensor werkt."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -743,42 +744,42 @@ msgstr ""
 " of er niets vastzit in de PTFE-buis. Controleer of de sensor goed leest."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Gebruikte filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "Bestand onvolledig. Toch doorgaan?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Voortgang afwerken"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Eerste laag kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Ten eerste zullen we de zelftest uitvoeren om de meest voorkomende "
 "montageproblemen te controleren."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Stromen"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -787,28 +788,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Voorzijde fan?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Voorkant [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Fans voor/links"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-Code is voor een ander niveau geslict. Doorgaan?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -817,14 +818,14 @@ msgstr ""
 " Druk geannuleerd."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-Code is voor een ander printertype geslict. Doorgaan?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -833,12 +834,12 @@ msgstr ""
 "alsjeblieft. Druk geannuleerd."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-Code is voor een nieuwere firmware geslict. Doorgaan?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -847,35 +848,35 @@ msgstr ""
 "alsjeblieft. Druk geannuleerd."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "HW Configuratie"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Verwarmer/Therm."
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Opwarmen"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Verwarming uitgeschakeld door veiligheidstimer."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Opwarmen klaar."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -886,7 +887,7 @@ msgstr ""
 "printen."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -895,8 +896,8 @@ msgstr ""
 "installatieproces?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Hoog verm."
 
@@ -907,48 +908,48 @@ msgid "Homing"
 msgstr "Startpositie"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend op 280C! Tuit vervangen en aangedraaid volgens specificaties?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Hotend fan:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Begin nu met xyz-kalibratie. Het kan tot 24 min. duren."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Begin nu met z-kalibratie."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "SPANROL STARTPOSFOUT"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "SPANROL BEWEGT NIET"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "CONTROLEER FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "ONGELDIG TOOL"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -957,27 +958,27 @@ msgstr ""
 "Instellingen - HW Setup - Staalplaten."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Verbetering van het bedijkingspunt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Info scherm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Init. SD kaart"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Voer filament in"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -985,7 +986,7 @@ msgstr ""
 "Steek a.u.b. filament (maar niet laden) in de extruder en druk op knop."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
@@ -993,272 +994,274 @@ msgstr ""
 "werken."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Is filament geladen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Ligt de staalplaat op het bed?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteratie"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Laatste print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Laatste printfouten"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Links"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Linker hotend fan?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Linkerkant[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Helder waard"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Dim waarde"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Lineaire correctie"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Live Z aanpassen"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Laad alle"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Filament laden"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Tot tuit laden"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Ladingstest"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Laden kleur"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Laden filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Losse riemschijf"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Hard"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW UPDATE NODIG"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware interne fout, reset de MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU REAGEERT NIET"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Retry: Temperatuur herstellen..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU ZELFTEST MISLUKT"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "MMU fout"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "MMU laadfout"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU reageert niet correct. Controleer de bedrading en connectoren."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU reageert niet. Controleer de bedrading en connectoren."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU verbonden"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Magnet. comp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Hoofdmenu"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Scheefheid"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Referentie hoogte van het kalibratiepunt meten"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Mesh bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Stand"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Moduswijziging bezig..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Meer details online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Verplaats X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Verplaats Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Verplaats Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "As verplaatsen"
 
@@ -1269,94 +1272,95 @@ msgid "Moving selector"
 msgstr "Bewege selector"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/V"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Nieuwe firmware versie beschikbaar:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Nee"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Geen SD kaart"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Geen beweging."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Geen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normaal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Niet verbonden"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Draait niet"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Begin met kalibratie tussen de tuit en het bed."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Opwarmen van de tuit voor PLA voor."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Verwijder nu de testprint van staalplaat."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Tuit"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Tuit wisselen"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Tuit d."
 
@@ -1367,82 +1371,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Uit"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Oude instellingen gevonden. Standaard PID, E-steps etc. instellingen worden "
 "geladen."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "Aan"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "Eenmaal"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSE TERMISCHE FOUT"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "PID kalibratie klaar"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "PID kalibratie"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "PINDA opwarmen"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "PINDA kalib."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "PINDA-kalibratie mislukt"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1451,7 +1455,7 @@ msgstr ""
 "menu Instellingen-> PINDA kalib."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "RIEMSCH. BEWEGT NIET"
 
@@ -1462,13 +1466,13 @@ msgid "Parking selector"
 msgstr "Parkere selector"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pauze"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Print pauzeren"
 
@@ -1479,7 +1483,7 @@ msgid "Performing cut"
 msgstr "Voer cut uit"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1488,7 +1492,7 @@ msgstr ""
 "tuit. Als de tuit het papier beweegt, onmiddellijk uitschakelen."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1497,36 +1501,36 @@ msgstr ""
 "wizard door de printer opnieuw te starten."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 "AUB IR sensor ver- binding kontrolleren , verwijder filament indien "
 "aanwezig."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Controleer aub:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Maak het bed schoon en druk op de knop."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Reinig de tuit voor de kalibratie. Druk op de knop wanneer gereed."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Steek a.u.b. filament in de extruder en druk op de knop om het te laden."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1535,104 +1539,104 @@ msgstr ""
 " te laden."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Laad a.u.b. eerst filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Open spanrol en verwijder filament handmatig."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Leg staalplaat op bed."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Druk op de knop om filament te verwijderen"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Trek onmiddellijk de filament eruit"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Verwijder eerst de transport beschermers."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Verwijder staalplaat van het bed."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Voer eerst de XYZ-kalibratie uit."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Verwijder eerst het filament en probeer het opnieuw."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Voer een upgrade uit"
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Even geduld aub"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Stroomstoringen"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Voorverwarmen"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Tuit voorverwarmen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Opwarmen van de tuit. Wacht aub."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Opwarm. te snijden"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Opwarm.te uitwerpen"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Opwarmen invoeren"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Opwarmen uitwerpen"
 
@@ -1643,48 +1647,48 @@ msgid "Preparing blade"
 msgstr "Bereid mes voor"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Druk op knop"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Druk op de knop om de tuit voor te verwarmen en door te gaan."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Print afgebroken"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Print fan:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Print van SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Print pauzeren"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Print tijd"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Printer IP-adres:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1693,12 +1697,12 @@ msgstr ""
 "steps, sectie Calibration flow."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Tuitdiameter wijkt af van de G-code. Doorgaan?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1707,7 +1711,7 @@ msgstr ""
 "de waarde in de instellingen. Afdrukken geannuleerd."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Riemschijf motor is vastgelopen. Controleer of de poelie kan bewegen en "
@@ -1720,32 +1724,32 @@ msgid "Pushing filament"
 msgstr "Duwe filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "QUEUE VOL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Achterkant[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Print herstellen"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Hernoem"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1754,24 +1758,24 @@ msgstr ""
 "de G-code voor filament index buiten bereik (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Print hervatten"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Hervatten print"
 
@@ -1782,7 +1786,7 @@ msgid "Retract from FINDA"
 msgstr "Intrekken van FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Retry"
 
@@ -1793,17 +1797,17 @@ msgid "Returning selector"
 msgstr "Selctor terugrijden"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Rechts"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Recht.kant[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1812,39 +1816,39 @@ msgstr ""
 " vanaf het begin. Doorgaan?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "SD kaart"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELECTOR STARTP_FOUT"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECTOR BEWEG FOUT"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "GESTOPT."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Zoeken bed kalibratiepunt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Selecteer"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1853,27 +1857,27 @@ msgstr ""
 " het schermmenu."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Kies filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Kies taal"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selecteer de voorverwarmingstemperatuur van de tuit die overeenkomt met uw "
 "materiaal."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Selecteer de temperatuur die overeenkomt met uw materiaal."
 
@@ -1884,74 +1888,74 @@ msgid "Selecting fil. slot"
 msgstr "Selectere fil. slot"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Zelftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Zelftest start"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Zelftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Zelftest fout!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Zelftest mislukt"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Zelftest zal worden uitgevoerd om nauwkeurige sensorloze auto positie te "
 "kalibreren."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Sensor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor geverifieerd, verwijder nu het filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Temp. instellen:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Instellingen"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Erg scheef"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Staalplaat"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1964,23 +1968,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Toon endstops"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Stil"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Beetje scheef"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1989,127 +1993,127 @@ msgstr ""
 "per map 100 is."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Er is een probleem opgetreden, Z-kalibratie afgedwongen ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Sort."
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Bestanden sorteren"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Geluid"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Snelheid"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Draait"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "En stabiele 21-26C omgevingstemperatuur is nodig,een stevige stand is "
 "vereist."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statistieken"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Stil"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Staalplaten"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Print stoppen"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Gewisseld"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "THERMISCHE ANOMALIE"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "TMC FOUT"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "TMC RESET"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC KORTSLUITING"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC OVERHITTINGSFOUT"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC ONDERVOLT. FOUT"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2118,27 +2122,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Thermo model nog ongekalibreerd."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Temperatuur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Temperaturen"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Teste filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2146,7 +2150,7 @@ msgstr ""
 "blokkeert."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2154,7 +2158,7 @@ msgstr ""
 "zit."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2165,7 +2169,7 @@ msgstr ""
 "(Calibration chapter)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2174,63 +2178,63 @@ msgstr ""
 "handleiding, hoofdstuk First steps, section Calibration flow."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Tijd"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Time-out"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Totaal"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Totaal fouten"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Totaal fil."
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Totaal printtijd"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Tune"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "ONTLAAD MANUEEL"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Ontla."
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Fil. uitwerpen"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Uitwerpen filament"
 
@@ -2247,23 +2251,23 @@ msgid "Unloading to pulley"
 msgstr "Ontlade n. riemschi."
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verificatie mislukt, verwijder het filament en probeer het opnieuw."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Spanning"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "WAARSCH. TMC TE HEET"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2276,198 +2280,192 @@ msgstr ""
 "Stealth stand"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Wacht op gebruiker.."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Wachten op afkoelen van PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Wachten op afkoelen van tuit en bed"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Waarsch."
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr ""
 "Waarschuwing: zowel het printertype als het moederbordtype is gewijzigd."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Waarschuwing: type moederbord gewijzigd."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Waarschuwing: printertype gewijzigd."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Is filament succes- vol verwijderd?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Aansluitingsfout"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "X-correctie"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "XYZ kal. details"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "XYZ-kalibratie in orde. Scheefheid zal automatisch worden gecorrigeerd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ-kalibratie in orde. X / Y-assen zijn licht scheef. Goed gedaan!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ-kalibratie niet gelukt. Voorste kalibratiepunten niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-kalibratie niet gelukt. Rechter voor kalibratiepunt niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-kalibratie mislukt. Bed ijkpunt niet gevonden."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ-kalibratie mislukt. Voorste kalibratiepunten niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-kalibratie mislukt. Raadpleeg de handleiding aub."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ-kalibratie mislukt. Rechter voor kalibratiepunt niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-kalibratie ok. X / Y-assen staan loodrecht. Gefeliciteerd!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Y afstand van min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Y-correctie"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "U kunt de wizard altijd hervatten via Kalibratie -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Z-correctie"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Z-test nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] punt offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "en druk op knop"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "om filament te laden"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "om fil. uitwerpen"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "onbekend"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "Status onbekend"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Refresh"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "MMU stroomstor."
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT UITGEWORPEN"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2476,12 +2474,12 @@ msgstr ""
 "geladen. Controleer de sensoren en bedrading."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "FOUT LADEN NA. EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2490,28 +2488,28 @@ msgstr ""
 "Verfijn de sensorkalibratie, indien nodig."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU FOUT"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Materailwisseling."
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Verwijder het uitgeworpen filament uit de voorkant van de MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2520,7 +2518,7 @@ msgstr ""
 "dat er geen fil. in de selector zit en dat FINDA naar behoren werkt."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2528,55 +2526,47 @@ msgstr ""
 "printer. Update naar versie 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Voorladen in MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "MK3-firmware bij MK3S-printer gedetecteerd"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "MK3S-firmware op MK3-printer ontdekt"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "ONBEKENDE FOUT"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Er is een onverwachte fout opgetreden."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Uitwerp."
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "FILAMENTWISSELING"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Laad"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "M600-filamentwissel. Laad een nieuw filament of werp het oude uit."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Sensitiviteit"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Bed leveling mislukt. Voer de Z-kalibratie uit."
 
@@ -2591,9 +2581,18 @@ msgid "Set not Ready"
 msgstr "Niet gereed zetten"
 
 #. MSG_REPRINT c=7
-#: ../../Firmware/ultralcd.cpp:5189
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Reprint"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Refresh"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "MK3-firmware bij MK3S-printer gedetecteerd"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "MK3S-firmware op MK3-printer ontdekt"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2580,7 +2580,7 @@ msgstr "Gereed zetten"
 msgid "Set not Ready"
 msgstr "Niet gereed zetten"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Reprint"

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 of ouder"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 of nieuwer"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "%s niveau verwacht"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Annuleren"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Z aanpassen"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Allemaal goed"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Klaar. Happy printing!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Altijd"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Kamertemp."
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "Zijn beide Z wagen heelemaal boven?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Startpositie"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Auto power"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "Autoladen filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,52 +113,52 @@ msgid "Avoiding grind"
 msgstr "Slijpen vermijden"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "As"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Aslengte"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Terug"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Bed"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Bed opwarmen"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Bed klaar"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Bed niveau correct"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -168,54 +167,54 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Bed/Verwarming"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Riem status"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Riemtest"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Stroomstoring. Print herstellen?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Helder"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Helderheid"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "COMMUNICATIEFOUT"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Kalibratie XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Kalibratie Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -224,13 +223,13 @@ msgstr ""
 " stoppers. Druk knop als klaar."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Kalibreren Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -239,28 +238,28 @@ msgstr ""
 "stoppers. Druk knop als klaar."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Kalibreren start"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Kalibratie"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Kalibratie klaar"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Kan selector of spanrol niet bewegen."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
@@ -268,128 +267,128 @@ msgstr ""
 "uitladen."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "SD verwijderd"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Wissel SD kaart"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Wissel filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Wissel geslaagd!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Wissel ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Controleer X as"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Controleer Y as"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Controleer Z as"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Controleer bed"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Controleer endstops"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Bestand controle"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Controleer hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Controleer sensors"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Checks"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "TM-fout wissen"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Kleur niet juist"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Van de community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Door."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Afkoelen"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Geselecteerde taal kopiëren?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Crashdet."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Crash gedetecteerd."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -400,34 +399,34 @@ msgstr ""
 "gebruikt worden"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Fil. knippen"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Mes"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Dim"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Uitschak"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Motoren uit"
 
@@ -439,8 +438,8 @@ msgid "Disengaging idler"
 msgstr "Ontkoppel spanrol"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -451,7 +450,7 @@ msgstr ""
 "calibration."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -459,14 +458,14 @@ msgstr ""
 "Wilt u de laatste stap herhalen om de afstand tussen de tuit en de bed "
 "opnieuw in te stellen?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Klaar"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "E-correctie"
 
@@ -495,13 +494,13 @@ msgid "ERR Wait for User"
 msgstr "FOUT Wacht gebruiker"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "FOUT:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Uitwerp. van MMU"
 
@@ -513,17 +512,17 @@ msgid "Ejecting filament"
 msgstr "Fil. word ontladen"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Eindstop"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Endstop niet geraakt"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Eindstops"
 
@@ -535,45 +534,45 @@ msgid "Engaging idler"
 msgstr "Koppel spanrol"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "F. autoladen"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "F.Jam ontdek."
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "FS. uitloop"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT AL GELADEN"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA TRIGGERDE NIET"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -582,7 +581,7 @@ msgstr ""
 "ontladen. Controleer of Fil. kan bewegen en of de FINDA werkt."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -591,65 +590,65 @@ msgstr ""
 " kan bewegen en FINDA werkt."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA NIET FIL.VRIJ"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "FS actie"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSEN. NIET AF GEGAAN"
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR TE VROEG"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. VAST"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME FOUT"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Foutstatistieken"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "MMU-Fouten"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Valse triggering"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Fan snelh."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Fan test"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Fans check"
 
@@ -678,46 +677,46 @@ msgid "Feeding to nozzle"
 msgstr "Voeding tot tuit"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Fil. fouten"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Fil. sensor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrudeert met de juiste kleur?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Fil. niet geladen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -726,7 +725,7 @@ msgstr ""
 "Controleer of het filament kan bewegen en de sensor werkt."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -735,7 +734,7 @@ msgstr ""
 "Controleer of het filament de fsensor heeft bereikt en de sensor werkt."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -744,42 +743,42 @@ msgstr ""
 " of er niets vastzit in de PTFE-buis. Controleer of de sensor goed leest."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Gebruikte filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "Bestand onvolledig. Toch doorgaan?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Voortgang afwerken"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Eerste laag kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Ten eerste zullen we de zelftest uitvoeren om de meest voorkomende "
 "montageproblemen te controleren."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Stromen"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -788,28 +787,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Voorzijde fan?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Voorkant [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Fans voor/links"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-Code is voor een ander niveau geslict. Doorgaan?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -818,14 +817,14 @@ msgstr ""
 " Druk geannuleerd."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-Code is voor een ander printertype geslict. Doorgaan?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -834,12 +833,12 @@ msgstr ""
 "alsjeblieft. Druk geannuleerd."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-Code is voor een nieuwere firmware geslict. Doorgaan?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -848,35 +847,35 @@ msgstr ""
 "alsjeblieft. Druk geannuleerd."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "HW Configuratie"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Verwarmer/Therm."
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Opwarmen"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Verwarming uitgeschakeld door veiligheidstimer."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Opwarmen klaar."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -887,7 +886,7 @@ msgstr ""
 "printen."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -896,8 +895,8 @@ msgstr ""
 "installatieproces?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Hoog verm."
 
@@ -908,48 +907,48 @@ msgid "Homing"
 msgstr "Startpositie"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend op 280C! Tuit vervangen en aangedraaid volgens specificaties?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Hotend fan:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Begin nu met xyz-kalibratie. Het kan tot 24 min. duren."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Begin nu met z-kalibratie."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "SPANROL STARTPOSFOUT"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "SPANROL BEWEGT NIET"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "CONTROLEER FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "ONGELDIG TOOL"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -958,27 +957,27 @@ msgstr ""
 "Instellingen - HW Setup - Staalplaten."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Verbetering van het bedijkingspunt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Info scherm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Init. SD kaart"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Voer filament in"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -986,7 +985,7 @@ msgstr ""
 "Steek a.u.b. filament (maar niet laden) in de extruder en druk op knop."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
@@ -994,274 +993,272 @@ msgstr ""
 "werken."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Is filament geladen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Ligt de staalplaat op het bed?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Iteratie"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Laatste print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Laatste printfouten"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Links"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Linker hotend fan?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Linkerkant[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Helder waard"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Dim waarde"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Lineaire correctie"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Live Z aanpassen"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Laad alle"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Filament laden"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Tot tuit laden"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Ladingstest"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Laden kleur"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Laden filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Losse riemschijf"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Hard"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW UPDATE NODIG"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware interne fout, reset de MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU REAGEERT NIET"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Retry: Temperatuur herstellen..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU ZELFTEST MISLUKT"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "MMU fout"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "MMU laadfout"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU reageert niet correct. Controleer de bedrading en connectoren."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU reageert niet. Controleer de bedrading en connectoren."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU verbonden"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Magnet. comp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Hoofdmenu"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Scheefheid"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Referentie hoogte van het kalibratiepunt meten"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Mesh bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Stand"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Moduswijziging bezig..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Meer details online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Verplaats X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Verplaats Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Verplaats Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "As verplaatsen"
 
@@ -1272,95 +1269,94 @@ msgid "Moving selector"
 msgstr "Bewege selector"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/V"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Nieuwe firmware versie beschikbaar:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Nee"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Geen SD kaart"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Geen beweging."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Geen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normaal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Niet verbonden"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Draait niet"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Begin met kalibratie tussen de tuit en het bed."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Opwarmen van de tuit voor PLA voor."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Verwijder nu de testprint van staalplaat."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Tuit"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Tuit wisselen"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Tuit d."
 
@@ -1371,82 +1367,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Uit"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Oude instellingen gevonden. Standaard PID, E-steps etc. instellingen worden "
 "geladen."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "Aan"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "Eenmaal"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSE TERMISCHE FOUT"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "PID kalibratie klaar"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "PID kalibratie"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "PINDA opwarmen"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "PINDA kalib."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "PINDA-kalibratie mislukt"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1455,7 +1451,7 @@ msgstr ""
 "menu Instellingen-> PINDA kalib."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "RIEMSCH. BEWEGT NIET"
 
@@ -1466,13 +1462,13 @@ msgid "Parking selector"
 msgstr "Parkere selector"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pauze"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Print pauzeren"
 
@@ -1483,7 +1479,7 @@ msgid "Performing cut"
 msgstr "Voer cut uit"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1492,7 +1488,7 @@ msgstr ""
 "tuit. Als de tuit het papier beweegt, onmiddellijk uitschakelen."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1501,36 +1497,36 @@ msgstr ""
 "wizard door de printer opnieuw te starten."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 "AUB IR sensor ver- binding kontrolleren , verwijder filament indien "
 "aanwezig."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Controleer aub:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Maak het bed schoon en druk op de knop."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Reinig de tuit voor de kalibratie. Druk op de knop wanneer gereed."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Steek a.u.b. filament in de extruder en druk op de knop om het te laden."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1539,104 +1535,104 @@ msgstr ""
 " te laden."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Laad a.u.b. eerst filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Open spanrol en verwijder filament handmatig."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Leg staalplaat op bed."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Druk op de knop om filament te verwijderen"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Trek onmiddellijk de filament eruit"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Verwijder eerst de transport beschermers."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Verwijder staalplaat van het bed."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Voer eerst de XYZ-kalibratie uit."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Verwijder eerst het filament en probeer het opnieuw."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Voer een upgrade uit"
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Even geduld aub"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Stroomstoringen"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Voorverwarmen"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Tuit voorverwarmen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Opwarmen van de tuit. Wacht aub."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Opwarm. te snijden"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Opwarm.te uitwerpen"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Opwarmen invoeren"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Opwarmen uitwerpen"
 
@@ -1647,48 +1643,48 @@ msgid "Preparing blade"
 msgstr "Bereid mes voor"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Druk op knop"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Druk op de knop om de tuit voor te verwarmen en door te gaan."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Print afgebroken"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Print fan:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Print van SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Print pauzeren"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Print tijd"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Printer IP-adres:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1697,12 +1693,12 @@ msgstr ""
 "steps, sectie Calibration flow."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Tuitdiameter wijkt af van de G-code. Doorgaan?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1711,7 +1707,7 @@ msgstr ""
 "de waarde in de instellingen. Afdrukken geannuleerd."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Riemschijf motor is vastgelopen. Controleer of de poelie kan bewegen en "
@@ -1724,32 +1720,32 @@ msgid "Pushing filament"
 msgstr "Duwe filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "QUEUE VOL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Achterkant[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Print herstellen"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Hernoem"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1758,24 +1754,24 @@ msgstr ""
 "de G-code voor filament index buiten bereik (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Print hervatten"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Hervatten print"
 
@@ -1786,7 +1782,7 @@ msgid "Retract from FINDA"
 msgstr "Intrekken van FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Retry"
 
@@ -1797,17 +1793,17 @@ msgid "Returning selector"
 msgstr "Selctor terugrijden"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Rechts"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Recht.kant[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1816,39 +1812,39 @@ msgstr ""
 " vanaf het begin. Doorgaan?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "SD kaart"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELECTOR STARTP_FOUT"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECTOR BEWEG FOUT"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "GESTOPT."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Zoeken bed kalibratiepunt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Selecteer"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1857,27 +1853,27 @@ msgstr ""
 " het schermmenu."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Kies filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Kies taal"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selecteer de voorverwarmingstemperatuur van de tuit die overeenkomt met uw "
 "materiaal."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Selecteer de temperatuur die overeenkomt met uw materiaal."
 
@@ -1888,74 +1884,74 @@ msgid "Selecting fil. slot"
 msgstr "Selectere fil. slot"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Zelftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Zelftest start"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Zelftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Zelftest fout!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Zelftest mislukt"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Zelftest zal worden uitgevoerd om nauwkeurige sensorloze auto positie te "
 "kalibreren."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Sensor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor geverifieerd, verwijder nu het filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Temp. instellen:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Instellingen"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Erg scheef"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Staalplaat"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1968,23 +1964,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Toon endstops"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Stil"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Beetje scheef"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1993,127 +1989,127 @@ msgstr ""
 "per map 100 is."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Er is een probleem opgetreden, Z-kalibratie afgedwongen ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Sort."
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Bestanden sorteren"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Geluid"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Snelheid"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Draait"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "En stabiele 21-26C omgevingstemperatuur is nodig,een stevige stand is "
 "vereist."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statistieken"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Stil"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Staalplaten"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Print stoppen"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Gewisseld"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "THERMISCHE ANOMALIE"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "TMC FOUT"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "TMC RESET"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC KORTSLUITING"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC OVERHITTINGSFOUT"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC ONDERVOLT. FOUT"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2122,27 +2118,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Thermo model nog ongekalibreerd."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Temperatuur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Temperaturen"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Teste filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2150,7 +2146,7 @@ msgstr ""
 "blokkeert."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2158,7 +2154,7 @@ msgstr ""
 "zit."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2169,7 +2165,7 @@ msgstr ""
 "(Calibration chapter)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2178,63 +2174,63 @@ msgstr ""
 "handleiding, hoofdstuk First steps, section Calibration flow."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Tijd"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Time-out"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Totaal"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Totaal fouten"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Totaal fil."
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Totaal printtijd"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Tune"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "ONTLAAD MANUEEL"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Ontla."
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Fil. uitwerpen"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Uitwerpen filament"
 
@@ -2251,23 +2247,23 @@ msgid "Unloading to pulley"
 msgstr "Ontlade n. riemschi."
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verificatie mislukt, verwijder het filament en probeer het opnieuw."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Spanning"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "WAARSCH. TMC TE HEET"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2280,192 +2276,198 @@ msgstr ""
 "Stealth stand"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Wacht op gebruiker.."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Wachten op afkoelen van PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Wachten op afkoelen van tuit en bed"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Waarsch."
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr ""
 "Waarschuwing: zowel het printertype als het moederbordtype is gewijzigd."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Waarschuwing: type moederbord gewijzigd."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Waarschuwing: printertype gewijzigd."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Is filament succes- vol verwijderd?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Aansluitingsfout"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "X-correctie"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "XYZ kal. details"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "XYZ-kalibratie in orde. Scheefheid zal automatisch worden gecorrigeerd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ-kalibratie in orde. X / Y-assen zijn licht scheef. Goed gedaan!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ-kalibratie niet gelukt. Voorste kalibratiepunten niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-kalibratie niet gelukt. Rechter voor kalibratiepunt niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-kalibratie mislukt. Bed ijkpunt niet gevonden."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ-kalibratie mislukt. Voorste kalibratiepunten niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-kalibratie mislukt. Raadpleeg de handleiding aub."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ-kalibratie mislukt. Rechter voor kalibratiepunt niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-kalibratie ok. X / Y-assen staan loodrecht. Gefeliciteerd!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Y afstand van min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Y-correctie"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "U kunt de wizard altijd hervatten via Kalibratie -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Z-correctie"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Z-test nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] punt offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "en druk op knop"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "om filament te laden"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "om fil. uitwerpen"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "onbekend"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "Status onbekend"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Refresh"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "MMU stroomstor."
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT UITGEWORPEN"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2474,12 +2476,12 @@ msgstr ""
 "geladen. Controleer de sensoren en bedrading."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "FOUT LADEN NA. EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2488,28 +2490,28 @@ msgstr ""
 "Verfijn de sensorkalibratie, indien nodig."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU FOUT"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Materailwisseling."
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Verwijder het uitgeworpen filament uit de voorkant van de MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2518,7 +2520,7 @@ msgstr ""
 "dat er geen fil. in de selector zit en dat FINDA naar behoren werkt."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2526,47 +2528,55 @@ msgstr ""
 "printer. Update naar versie 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Voorladen in MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "MK3-firmware bij MK3S-printer gedetecteerd"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "MK3S-firmware op MK3-printer ontdekt"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "ONBEKENDE FOUT"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Er is een onverwachte fout opgetreden."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Uitwerp."
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "FILAMENTWISSELING"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Laad"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "M600-filamentwissel. Laad een nieuw filament of werp het oude uit."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Sensitiviteit"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Bed leveling mislukt. Voer de Z-kalibratie uit."
 
@@ -2583,16 +2593,7 @@ msgstr "Niet gereed zetten"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Reprint"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Refresh"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "MK3-firmware bij MK3S-printer gedetecteerd"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "MK3S-firmware op MK3-printer ontdekt"
+msgstr "Herhaal druk"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 eller eldre"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 eller nyere"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "%s nivå ventet"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Avbryt"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Justerer Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Alt korrekt"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Alt klart. God printing!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Alltid"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Omgivelse"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "Er venstre og høyre Z-vogn helt oppe?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Hjelp"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Auto hjem"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Autostyrke"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "AutoLast filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Unngår sliping"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Akse"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Akselengde"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Tilbake"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Seng"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Sengen varmes"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Seng ferdig"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Plankorrekt seng"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +168,54 @@ msgstr ""
 "omstart."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Seng/Varmer"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Beltestatus"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Belte test"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Oppdaget Strømbrudd! Gjenoppta print?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Lys"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Lysstyrke"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "KOMMUNIKASJONSFEIL"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Kalibrer XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Kalibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +224,13 @@ msgstr ""
 "Deretter trykk."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Kalibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,156 +239,156 @@ msgstr ""
 " trykk."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Kalibrerer hjem"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Kalibrering"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Kalibrering ferdig"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Kan ikke flytte velger eller tomgangshjul"
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "Kan ikke utføre handling, filamentet er allerede lasted. Avless det først."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "Kort fjernet"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Bytt SD kort"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Bytt filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Bytte vellykket!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Byttet riktig?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Sjekker X aksen"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Sjekker Y aksen"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Sjekker Z aksen"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Sjekker seng"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Sjekker endesensorer"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Sjekker fil"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Sjekker hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Sjekker sensorer"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "G-code sjekk"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "Fjern TM-feil"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Farge ikke riktig"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Community laget"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Fort."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Nedkjøling"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Kopiere det valgte språket?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Krasj"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Krasjdetek."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Krasj oppdaget."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -398,34 +399,34 @@ msgstr ""
 "Normal modus"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Kutt filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Kutter"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Dato:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Svak"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Deaktiv."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Frigjør motorer"
 
@@ -437,8 +438,8 @@ msgid "Disengaging idler"
 msgstr "Frigjør tomgangshjul"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -448,7 +449,7 @@ msgstr ""
 "manualen, under First Steps, for hvordan det første laget skal kalibreres."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -456,14 +457,14 @@ msgstr ""
 "Vil du repetere det siste trinnet for å omjustere avstanden mellom dysen og "
 "platen?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Ferdig"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "E-korreksjon"
 
@@ -492,13 +493,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Vent på Bruker"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "FEIL:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Løs ut fra MMU"
 
@@ -510,17 +511,17 @@ msgid "Ejecting filament"
 msgstr "Mater ut filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Endesensor"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Traff ikke endesens."
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Endesensorer"
 
@@ -532,45 +533,45 @@ msgid "Engaging idler"
 msgstr "Aktiverer tomgangsh."
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Ekstruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Ekstruderinfo"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "F. autolast"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "F. kork føle"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "F. Løput"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT ALLEREDE LA"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA IKKE UTLØST"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -579,7 +580,7 @@ msgstr ""
 "Sikre at filamentet kan beveges og FINDA fungerer."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -588,65 +589,65 @@ msgstr ""
 "beveges og FINDA fungerer."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. FAST"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "FS aksjon"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR IKKE TIRGG."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR FOR TIDLIG"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL FAST"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME FEIL"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Feilstatistikk"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "Feil stat. MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Falskt utløsning"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Viftehastighet"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Viftetest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Viftesjekk"
 
@@ -675,46 +676,46 @@ msgid "Feeding to nozzle"
 msgstr "Mater til dyse"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Tomt filament"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Fil. Sensor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Kommer Filament ut og har riktig farge?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Fil. ikke lastet"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -723,7 +724,7 @@ msgstr ""
 "filamentet kan beveges og sensoren fungerer."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -732,7 +733,7 @@ msgstr ""
 "filamentet rekker fsensor og at sensoren fungerer."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -741,40 +742,40 @@ msgstr ""
 "ingenting står fast i PTFE røret. Sjekk at sensoren leser riktig."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Brukt filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "Fil er ukomplett. Fortsette allikevel?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Avslutter bevegelser"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Førstelagskal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Først skal jeg kjøre en selvtest for å sjekke vanlige byggefeil."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Flyt"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -783,28 +784,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Fremre printvifte?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Fremsiden [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Fremre/venstre vifte"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code sliced for en annen høyde. Fortsette?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -812,14 +813,14 @@ msgstr ""
 "G-code sliced for en annen høyde. Vennligst slice igjen. Print avbrutt."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code sliced for en annen printer. Fortsette?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -827,12 +828,12 @@ msgstr ""
 "G-code sliced for en annen printer. Vennligst slice igjen. Print avbrutt."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code sliced for nyere fastvare. Fortsette?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -841,35 +842,35 @@ msgstr ""
 "avbrutt."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "GW oppsett"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Varmer/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Varmer opp"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Varme skrudd av pga. sikkerhet."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Oppvarming ferdig."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -879,7 +880,7 @@ msgstr ""
 "oppsett, hvor Z aksen blir kalibrert. Du er da klar til å printe."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -888,8 +889,8 @@ msgstr ""
 "gjennom oppsettprosessen?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Høy styrke"
 
@@ -900,48 +901,48 @@ msgid "Homing"
 msgstr "Søker"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend på 280C! Dyse byttet og strammet til spesifikasjonene?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Hotend-vifte:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Nå skal jeg kjøre kalibreringen. Det kan ta opptil 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Nå kjører jeg Z-kalibreringen."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "IDLER CANNOT HOME"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "IDLER CANNOT MOVE"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "KONTROLLER FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "UGYLDIG VERKTØY"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -950,305 +951,307 @@ msgstr ""
 "Stålplater."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Forbedrer seng kalibreringspunkt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Infoskjerm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Init. SD kort"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Sett inn filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Sett inn filamentet i ekstruderen og deretter trykk inn valghjulet."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Intern runtime feil. Prøv omstart av MMU eller oppdater fastvaren."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Er filament lastet?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Er stålplaten på varmesenga?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iterasjon"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Siste print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Siste printfeil"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Venstre"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Venst. hotendvifte?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Vens. side[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Nivå Lyst"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Nivå Dimmet"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Lin. korreksjon"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Juster Live-Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Last Alle"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Last inn filam."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Last til dysen"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Lastetest"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Laster farge"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Laster filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Løs reim"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Høyt"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FV OPPDAT. NØDVE"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU fastvare intern feil, vennligst nullstill MMU-en."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "MMU Mod."
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU SVARER IKKE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Retry: gjenoppretter temperatur..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELVTEST FEILET"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "MMU feil"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "MMU lastefeil"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU svarer ikke riktig. Sjekk ledninger og koblinger."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU svarer ikke. Sjekk ledninger og koblinger."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU tilkoblet"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Magnet komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Hovedmeny"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Målt skjevhet"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Måler referansehøyde for kalibreringspunkt"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Plan-nett"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Sengeplanering"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Modus"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Modus endres..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Flere detaljer online"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Beveg X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Beveg Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Beveg Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Beveg akse"
 
@@ -1259,94 +1262,95 @@ msgid "Moving selector"
 msgstr "Flytter velger"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr " -"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Ny fastvare tilgjengelig:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Nei"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "SD-kort mangler"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Ingen bevegelse."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Ingen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Ikke tilkoblet"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Spinner ikke"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Jeg vil nå kalibrere avstanden mellom tuppen av dysen og varmeplaten."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jeg vil nå forvarme dysen for PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Fjern nå testprintet fra stålplaten."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Dyse"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Dysebytte"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Dyse diam."
 
@@ -1357,81 +1361,81 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Av"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Gamle verdier funnet Standarinnstillinger for PID, Esteg etc. blir satt."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "På"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "En gang"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSET THERMISK FEIL"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "PID kal. ferdig"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "PID kalibrering"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "PINDA varmes"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibrering mislyktes"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1440,7 +1444,7 @@ msgstr ""
 "under Innstillinger -> PINDA kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "REIM UBEVEGELIG"
 
@@ -1451,13 +1455,13 @@ msgid "Parking selector"
 msgstr "Parkerer velger"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Pause printjobben"
 
@@ -1468,7 +1472,7 @@ msgid "Performing cut"
 msgstr "Utfører kutt"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1477,7 +1481,7 @@ msgstr ""
 "dysen tar papiret, skru umiddelbart av printeren."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1486,34 +1490,34 @@ msgstr ""
 "omstarte printeren."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 "Vennligst sjekk koblingen til IR sensorer. Last ut filament om lastet."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Venligst sjekk:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Rengjør stålplaten og trykk valghjulet."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Rengjør dysen og trykk valghjulet."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Sett inn filament I ekstruderen og trykk valghjulet for å laste."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1522,105 +1526,105 @@ msgstr ""
 "laste."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Vennligst sett inn filament først."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Åpne taljedøren og fjern filamentet for hånd."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Plasser stålplaten på varmesenga."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Trykk valghjulet for å ta ut filamentet"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Trekk ut filamented med en gang"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Vennligst fjern sendingsbeskyttelsen først."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Vennligst ta stålplaten av varmesenga."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Vennligst fullfør XYZ kalibreringen først."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 "Vennligst last ut filamentet først, deretter repeter denne handlingen."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Vennligst oppdater."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Vennligst vent"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Strømfeil"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Forvarming"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Forvarm dysen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Forvarmer dysen. Vennligst vent..."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Forvarmer for kutt"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Forvarmer for utmat."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Forvarmer for last"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Forvarmer for fil."
 
@@ -1631,48 +1635,48 @@ msgid "Preparing blade"
 msgstr "Forbereder blad"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Trykk valghjulet"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Trykk valghjulet for å forvarme dysen og fortsette."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Print avbrutt"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Printvifte:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Print fra SD-kort"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Print satt på pause"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Printetid"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Printer IP adr.:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1680,12 +1684,12 @@ msgstr ""
 "Printeren er ikke kalibrert. Vennligst se manualen, under First Steps."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Dysediameteren er forskjellig fra G-Code. Fortsette?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1694,7 +1698,7 @@ msgstr ""
 "hva som er satt. Print avbrutt."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr "Reimmotor stanset. Sjekk at Reimen kan beveges og sjekk koblinger"
 
@@ -1705,32 +1709,32 @@ msgid "Pushing filament"
 msgstr "Dytter filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "FULL KØ"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Baksiden [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Gjenopptar print"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Gi nytt navn"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1739,24 +1743,24 @@ msgstr ""
 "g-code for verktøys-inteks ut av rekkevidde (T0-T4)"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Nullstill"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Nullstill XYZ kal."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Gjenoppta print"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Gjenopptar print"
 
@@ -1767,7 +1771,7 @@ msgid "Retract from FINDA"
 msgstr "ta tilbake fra FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Retry"
 
@@ -1778,17 +1782,17 @@ msgid "Returning selector"
 msgstr "Returnerer velger"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Høyre"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Høyre side[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1797,64 +1801,64 @@ msgstr ""
 "begynne på nytt. Fortsette?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "SD-kort"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "VELGER KAN IKKE HOME"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELEKTOR STÅR FAST"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "STOPPET."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Søker etter kalibreringspunkt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Velg"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Velg filamenttype for Førstelags- kalibrering."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Velg filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Velg språk"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Velg dysetemperatur som passer ditt materiale."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Velg temperaturen som passer ditt materiale."
 
@@ -1865,73 +1869,73 @@ msgid "Selecting fil. slot"
 msgstr "Velger fil. spor"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Selvtest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Selvtest starter"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Selvtest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Selvtest feil!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Selvtest feilet"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Selvtest vil bli kjørt for å kalibrere nøyaktig sensorløs hjemposisjon."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Sensorinformasjon"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verifiserte, fjern filamentet nå."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Satt temperatur:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Innstillinger"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Stor skjevhet"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Plate"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1944,149 +1948,149 @@ msgstr ""
 "%cNullstill"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Vis endesensorer"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Lydløs"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Lett skjevhet"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
 msgstr "Noen filer vil ikke bli sortert. Maks antall filer i en mappe er 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problem møtt. Z aksjeplanering tvunget ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Sorter"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Sorter filer"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Lyd"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Hastighet"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Spinner"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "En stabil rom- temperatur på 21-26C og et solid underlag er nødvendig."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statistikk"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Stille"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Stål plate"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Stopp printjobb"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Streng"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "System info"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Byttet"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "THERMISK ANOMALI"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "TMC DRIVER FEIL"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "TMC DRIVER NULLSTILL"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRIVER KORTSLUTT"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC OVEROPPHETING"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC LAVSPENNING FEIL"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2095,41 +2099,41 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Termisk modell ikke kalibrert enda."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Temperaturer"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Tester filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
 "Idleren kan ikke gå hjem riktig. sjekk om noe står i veien for bevegelsen."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
 "Velgeren kan ikke gå hjem riktig. sjekk om noe står i veien for bevegelsen."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2140,7 +2144,7 @@ msgstr ""
 "skal se ut."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2149,63 +2153,63 @@ msgstr ""
 "hovedmenyen og følg Veilederen."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Dato"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Tidsavbrudd"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Totalt"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Feil totalt"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Filament totalt"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Printetid totalt"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Juster"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "LAST UT MANUELT"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Last ut"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Last ut filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Laster ut filament"
 
@@ -2222,23 +2226,23 @@ msgid "Unloading to pulley"
 msgstr "Utlaster til trinse"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifisering feilet. Fjern filamentet og prøv igjen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Strøm/Volt"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "VARSEL TMC FOR VARM"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2251,197 +2255,191 @@ msgstr ""
 "Stillemodus"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Venter på bruker..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Venter på PINDA nedkjøling"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Venter på dyse- og platenedkjøling"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Advarsel"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Advarsel: Både printertype og hovedkortype er forandret."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Advarsel: Hovedkortype forandret."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Advarsel: Printertype forandret."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Ble filamentet lastet helt ut?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Koblingsfeil"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Veileder"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "X-korreksjon"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "XYZ cal. detaljer"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ kalibreringen er grei. Skjevhet blir justert automatisk."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ kalibreringen er god. Godt jobba!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ kalibreringen feilet. Front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "XYZ kalibreringen feilet. Høyre front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ kalibreringen feilet. Kalibreringspunkt ikke funnet."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ kalibreringen feilet. Front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kal. mislyktes. Vennligst rådfør med håndboken."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ kalibreringen feilet. Høyre front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 "XYZ kalibrering OK.\n"
 "X og Y aksen er perpendikulær. Gratulerer!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Y distanse fra min."
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Y-korreksjon"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Du kan alltid starte Veilederen fra Kalibrering -> Veileder."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Z-korreksjon"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Z-sensor nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] punktforskyv."
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "og trykk på knappen"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "for filamentlast"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "for filament ut"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "ukjent"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "ukjent tilstand"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Forfriske"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "MMU strøm feil"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT UTSETTET"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2450,12 +2448,12 @@ msgstr ""
 "sensorene og ledningene."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "MISLUKT LAST EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2464,28 +2462,28 @@ msgstr ""
 "sensorkalibreringen om nødvendig."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU FEIL"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Materialutveksling"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Fjern det utkastede filamentet fra fronten av MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2494,7 +2492,7 @@ msgstr ""
 " for at ingen fil. er i velgeren og at FINDA fungerer som den skal."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2502,55 +2500,47 @@ msgstr ""
 "versjon 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Forlast til MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "MK3 system funnet på MK3S printer"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "MK3S systemvare funnet på MK3 printer"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "UKJENT FEIL"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Det oppstod en uventet feil."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Løs ut"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "ENDRING AV FILAMENT"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Last"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "M600 filamentskifte. Sett inn en ny filament eller løs ut den gamle."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Sensitivitet"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Sengeplanering feilet. Kjør Z-kalibrering."
 
@@ -2564,10 +2554,19 @@ msgstr "Gjør klar"
 msgid "Set not Ready"
 msgstr "Sett ikke klar"
 
-#. MSG_REPRINT c=8
-#: ../../Firmware/ultralcd.cpp:5189
+#. MSG_REPRINT c=7
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Opptrykk"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Forfriske"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "MK3 system funnet på MK3S printer"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "MK3S systemvare funnet på MK3 printer"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamle filamentet og trykk valghjulet for å laste et nytt."

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2564,6 +2564,11 @@ msgstr "Gjør klar"
 msgid "Set not Ready"
 msgstr "Sett ikke klar"
 
+#. MSG_REPRINT c=8
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Opptrykk"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamle filamentet og trykk valghjulet for å laste et nytt."
 

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 eller eldre"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 eller nyere"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "%s nivå ventet"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Avbryt"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Justerer Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Alt korrekt"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Alt klart. God printing!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Alltid"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Omgivelse"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "Er venstre og høyre Z-vogn helt oppe?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Hjelp"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Auto hjem"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Autostyrke"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "AutoLast filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,52 +113,52 @@ msgid "Avoiding grind"
 msgstr "Unngår sliping"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Akse"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Akselengde"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Tilbake"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Seng"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Sengen varmes"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Seng ferdig"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Plankorrekt seng"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -168,54 +167,54 @@ msgstr ""
 "omstart."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Seng/Varmer"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Beltestatus"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Belte test"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Oppdaget Strømbrudd! Gjenoppta print?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Lys"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Lysstyrke"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "KOMMUNIKASJONSFEIL"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Kalibrer XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Kalibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -224,13 +223,13 @@ msgstr ""
 "Deretter trykk."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Kalibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -239,156 +238,156 @@ msgstr ""
 " trykk."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Kalibrerer hjem"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Kalibrering"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Kalibrering ferdig"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Kan ikke flytte velger eller tomgangshjul"
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "Kan ikke utføre handling, filamentet er allerede lasted. Avless det først."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "Kort fjernet"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Bytt SD kort"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Bytt filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Bytte vellykket!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Byttet riktig?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Sjekker X aksen"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Sjekker Y aksen"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Sjekker Z aksen"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Sjekker seng"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Sjekker endesensorer"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Sjekker fil"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Sjekker hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Sjekker sensorer"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "G-code sjekk"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "Fjern TM-feil"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Farge ikke riktig"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Community laget"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Fort."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Nedkjøling"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Kopiere det valgte språket?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Krasj"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Krasjdetek."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Krasj oppdaget."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -399,34 +398,34 @@ msgstr ""
 "Normal modus"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Kutt filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Kutter"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Dato:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Svak"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Deaktiv."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Frigjør motorer"
 
@@ -438,8 +437,8 @@ msgid "Disengaging idler"
 msgstr "Frigjør tomgangshjul"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -449,7 +448,7 @@ msgstr ""
 "manualen, under First Steps, for hvordan det første laget skal kalibreres."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -457,14 +456,14 @@ msgstr ""
 "Vil du repetere det siste trinnet for å omjustere avstanden mellom dysen og "
 "platen?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Ferdig"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "E-korreksjon"
 
@@ -493,13 +492,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Vent på Bruker"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "FEIL:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Løs ut fra MMU"
 
@@ -511,17 +510,17 @@ msgid "Ejecting filament"
 msgstr "Mater ut filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Endesensor"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Traff ikke endesens."
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Endesensorer"
 
@@ -533,45 +532,45 @@ msgid "Engaging idler"
 msgstr "Aktiverer tomgangsh."
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Ekstruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Ekstruderinfo"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "F. autolast"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "F. kork føle"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "F. Løput"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT ALLEREDE LA"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA IKKE UTLØST"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -580,7 +579,7 @@ msgstr ""
 "Sikre at filamentet kan beveges og FINDA fungerer."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -589,65 +588,65 @@ msgstr ""
 "beveges og FINDA fungerer."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. FAST"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "FS aksjon"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR IKKE TIRGG."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR FOR TIDLIG"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL FAST"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME FEIL"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Feilstatistikk"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "Feil stat. MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Falskt utløsning"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Viftehastighet"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Viftetest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Viftesjekk"
 
@@ -676,46 +675,46 @@ msgid "Feeding to nozzle"
 msgstr "Mater til dyse"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Tomt filament"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Fil. Sensor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Kommer Filament ut og har riktig farge?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Fil. ikke lastet"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -724,7 +723,7 @@ msgstr ""
 "filamentet kan beveges og sensoren fungerer."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -733,7 +732,7 @@ msgstr ""
 "filamentet rekker fsensor og at sensoren fungerer."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -742,40 +741,40 @@ msgstr ""
 "ingenting står fast i PTFE røret. Sjekk at sensoren leser riktig."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Brukt filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "Fil er ukomplett. Fortsette allikevel?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Avslutter bevegelser"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Førstelagskal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Først skal jeg kjøre en selvtest for å sjekke vanlige byggefeil."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Flyt"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -784,28 +783,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Fremre printvifte?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Fremsiden [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Fremre/venstre vifte"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code sliced for en annen høyde. Fortsette?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -813,14 +812,14 @@ msgstr ""
 "G-code sliced for en annen høyde. Vennligst slice igjen. Print avbrutt."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code sliced for en annen printer. Fortsette?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -828,12 +827,12 @@ msgstr ""
 "G-code sliced for en annen printer. Vennligst slice igjen. Print avbrutt."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code sliced for nyere fastvare. Fortsette?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -842,35 +841,35 @@ msgstr ""
 "avbrutt."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "GW oppsett"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Varmer/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Varmer opp"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Varme skrudd av pga. sikkerhet."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Oppvarming ferdig."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -880,7 +879,7 @@ msgstr ""
 "oppsett, hvor Z aksen blir kalibrert. Du er da klar til å printe."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -889,8 +888,8 @@ msgstr ""
 "gjennom oppsettprosessen?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Høy styrke"
 
@@ -901,48 +900,48 @@ msgid "Homing"
 msgstr "Søker"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend på 280C! Dyse byttet og strammet til spesifikasjonene?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Hotend-vifte:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Nå skal jeg kjøre kalibreringen. Det kan ta opptil 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Nå kjører jeg Z-kalibreringen."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "IDLER CANNOT HOME"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "IDLER CANNOT MOVE"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "KONTROLLER FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "UGYLDIG VERKTØY"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -951,307 +950,305 @@ msgstr ""
 "Stålplater."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Forbedrer seng kalibreringspunkt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Infoskjerm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Init. SD kort"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Sett inn filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Sett inn filamentet i ekstruderen og deretter trykk inn valghjulet."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Intern runtime feil. Prøv omstart av MMU eller oppdater fastvaren."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Er filament lastet?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Er stålplaten på varmesenga?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Iterasjon"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Siste print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Siste printfeil"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Venstre"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Venst. hotendvifte?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Vens. side[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Nivå Lyst"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Nivå Dimmet"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Lin. korreksjon"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Juster Live-Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Last Alle"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Last inn filam."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Last til dysen"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Lastetest"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Laster farge"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Laster filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Løs reim"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Høyt"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FV OPPDAT. NØDVE"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU fastvare intern feil, vennligst nullstill MMU-en."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "MMU Mod."
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU SVARER IKKE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Retry: gjenoppretter temperatur..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELVTEST FEILET"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "MMU feil"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "MMU lastefeil"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU svarer ikke riktig. Sjekk ledninger og koblinger."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU svarer ikke. Sjekk ledninger og koblinger."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU tilkoblet"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Magnet komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Hovedmeny"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Målt skjevhet"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Måler referansehøyde for kalibreringspunkt"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Plan-nett"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Sengeplanering"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Modus"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Modus endres..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Flere detaljer online"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Beveg X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Beveg Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Beveg Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Beveg akse"
 
@@ -1262,95 +1259,94 @@ msgid "Moving selector"
 msgstr "Flytter velger"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr " -"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Ny fastvare tilgjengelig:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Nei"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "SD-kort mangler"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Ingen bevegelse."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Ingen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Ikke tilkoblet"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Spinner ikke"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Jeg vil nå kalibrere avstanden mellom tuppen av dysen og varmeplaten."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jeg vil nå forvarme dysen for PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Fjern nå testprintet fra stålplaten."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Dyse"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Dysebytte"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Dyse diam."
 
@@ -1361,81 +1357,81 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Av"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Gamle verdier funnet Standarinnstillinger for PID, Esteg etc. blir satt."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "På"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "En gang"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSET THERMISK FEIL"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "PID kal. ferdig"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "PID kalibrering"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "PINDA varmes"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibrering mislyktes"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1444,7 +1440,7 @@ msgstr ""
 "under Innstillinger -> PINDA kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "REIM UBEVEGELIG"
 
@@ -1455,13 +1451,13 @@ msgid "Parking selector"
 msgstr "Parkerer velger"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Pause printjobben"
 
@@ -1472,7 +1468,7 @@ msgid "Performing cut"
 msgstr "Utfører kutt"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1481,7 +1477,7 @@ msgstr ""
 "dysen tar papiret, skru umiddelbart av printeren."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1490,34 +1486,34 @@ msgstr ""
 "omstarte printeren."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 "Vennligst sjekk koblingen til IR sensorer. Last ut filament om lastet."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Venligst sjekk:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Rengjør stålplaten og trykk valghjulet."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Rengjør dysen og trykk valghjulet."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Sett inn filament I ekstruderen og trykk valghjulet for å laste."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1526,105 +1522,105 @@ msgstr ""
 "laste."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Vennligst sett inn filament først."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Åpne taljedøren og fjern filamentet for hånd."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Plasser stålplaten på varmesenga."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Trykk valghjulet for å ta ut filamentet"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Trekk ut filamented med en gang"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Vennligst fjern sendingsbeskyttelsen først."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Vennligst ta stålplaten av varmesenga."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Vennligst fullfør XYZ kalibreringen først."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 "Vennligst last ut filamentet først, deretter repeter denne handlingen."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Vennligst oppdater."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Vennligst vent"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Strømfeil"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Forvarming"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Forvarm dysen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Forvarmer dysen. Vennligst vent..."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Forvarmer for kutt"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Forvarmer for utmat."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Forvarmer for last"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Forvarmer for fil."
 
@@ -1635,48 +1631,48 @@ msgid "Preparing blade"
 msgstr "Forbereder blad"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Trykk valghjulet"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Trykk valghjulet for å forvarme dysen og fortsette."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Print avbrutt"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Printvifte:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Print fra SD-kort"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Print satt på pause"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Printetid"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Printer IP adr.:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1684,12 +1680,12 @@ msgstr ""
 "Printeren er ikke kalibrert. Vennligst se manualen, under First Steps."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Dysediameteren er forskjellig fra G-Code. Fortsette?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1698,7 +1694,7 @@ msgstr ""
 "hva som er satt. Print avbrutt."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr "Reimmotor stanset. Sjekk at Reimen kan beveges og sjekk koblinger"
 
@@ -1709,32 +1705,32 @@ msgid "Pushing filament"
 msgstr "Dytter filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "FULL KØ"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Baksiden [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Gjenopptar print"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Gi nytt navn"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1743,24 +1739,24 @@ msgstr ""
 "g-code for verktøys-inteks ut av rekkevidde (T0-T4)"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Nullstill"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Nullstill XYZ kal."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Gjenoppta print"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Gjenopptar print"
 
@@ -1771,7 +1767,7 @@ msgid "Retract from FINDA"
 msgstr "ta tilbake fra FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Retry"
 
@@ -1782,17 +1778,17 @@ msgid "Returning selector"
 msgstr "Returnerer velger"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Høyre"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Høyre side[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1801,64 +1797,64 @@ msgstr ""
 "begynne på nytt. Fortsette?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "SD-kort"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "VELGER KAN IKKE HOME"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELEKTOR STÅR FAST"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "STOPPET."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Søker etter kalibreringspunkt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Velg"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Velg filamenttype for Førstelags- kalibrering."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Velg filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Velg språk"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Velg dysetemperatur som passer ditt materiale."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Velg temperaturen som passer ditt materiale."
 
@@ -1869,73 +1865,73 @@ msgid "Selecting fil. slot"
 msgstr "Velger fil. spor"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Selvtest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Selvtest starter"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Selvtest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Selvtest feil!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Selvtest feilet"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Selvtest vil bli kjørt for å kalibrere nøyaktig sensorløs hjemposisjon."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Sensorinformasjon"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verifiserte, fjern filamentet nå."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Satt temperatur:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Innstillinger"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Stor skjevhet"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Plate"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1948,149 +1944,149 @@ msgstr ""
 "%cNullstill"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Vis endesensorer"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Lydløs"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Lett skjevhet"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
 msgstr "Noen filer vil ikke bli sortert. Maks antall filer i en mappe er 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problem møtt. Z aksjeplanering tvunget ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Sorter"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Sorter filer"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Lyd"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Hastighet"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Spinner"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "En stabil rom- temperatur på 21-26C og et solid underlag er nødvendig."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statistikk"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Stille"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Stål plate"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Stopp printjobb"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Streng"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "System info"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Byttet"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "THERMISK ANOMALI"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "TMC DRIVER FEIL"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "TMC DRIVER NULLSTILL"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRIVER KORTSLUTT"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC OVEROPPHETING"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC LAVSPENNING FEIL"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2099,41 +2095,41 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Termisk modell ikke kalibrert enda."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Temperaturer"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Tester filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
 "Idleren kan ikke gå hjem riktig. sjekk om noe står i veien for bevegelsen."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
 "Velgeren kan ikke gå hjem riktig. sjekk om noe står i veien for bevegelsen."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2144,7 +2140,7 @@ msgstr ""
 "skal se ut."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2153,63 +2149,63 @@ msgstr ""
 "hovedmenyen og følg Veilederen."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Dato"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Tidsavbrudd"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Totalt"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Feil totalt"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Filament totalt"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Printetid totalt"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Juster"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "LAST UT MANUELT"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Last ut"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Last ut filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Laster ut filament"
 
@@ -2226,23 +2222,23 @@ msgid "Unloading to pulley"
 msgstr "Utlaster til trinse"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifisering feilet. Fjern filamentet og prøv igjen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Strøm/Volt"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "VARSEL TMC FOR VARM"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2255,191 +2251,197 @@ msgstr ""
 "Stillemodus"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Venter på bruker..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Venter på PINDA nedkjøling"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Venter på dyse- og platenedkjøling"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Advarsel"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Advarsel: Både printertype og hovedkortype er forandret."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Advarsel: Hovedkortype forandret."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Advarsel: Printertype forandret."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Ble filamentet lastet helt ut?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Koblingsfeil"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Veileder"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "X-korreksjon"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "XYZ cal. detaljer"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ kalibreringen er grei. Skjevhet blir justert automatisk."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ kalibreringen er god. Godt jobba!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ kalibreringen feilet. Front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "XYZ kalibreringen feilet. Høyre front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ kalibreringen feilet. Kalibreringspunkt ikke funnet."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ kalibreringen feilet. Front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kal. mislyktes. Vennligst rådfør med håndboken."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ kalibreringen feilet. Høyre front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 "XYZ kalibrering OK.\n"
 "X og Y aksen er perpendikulær. Gratulerer!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Y distanse fra min."
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Y-korreksjon"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Du kan alltid starte Veilederen fra Kalibrering -> Veileder."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Z-korreksjon"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Z-sensor nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] punktforskyv."
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "og trykk på knappen"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "for filamentlast"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "for filament ut"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "ukjent"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "ukjent tilstand"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Forfriske"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "MMU strøm feil"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT UTSETTET"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2448,12 +2450,12 @@ msgstr ""
 "sensorene og ledningene."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "MISLUKT LAST EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2462,28 +2464,28 @@ msgstr ""
 "sensorkalibreringen om nødvendig."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU FEIL"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Materialutveksling"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Fjern det utkastede filamentet fra fronten av MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2492,7 +2494,7 @@ msgstr ""
 " for at ingen fil. er i velgeren og at FINDA fungerer som den skal."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2500,47 +2502,55 @@ msgstr ""
 "versjon 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Forlast til MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "MK3 system funnet på MK3S printer"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "MK3S systemvare funnet på MK3 printer"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "UKJENT FEIL"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Det oppstod en uventet feil."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Løs ut"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "ENDRING AV FILAMENT"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Last"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "M600 filamentskifte. Sett inn en ny filament eller løs ut den gamle."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Sensitivitet"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Sengeplanering feilet. Kjør Z-kalibrering."
 
@@ -2557,16 +2567,7 @@ msgstr "Sett ikke klar"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Opptrykk"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Forfriske"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "MK3 system funnet på MK3S printer"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "MK3S systemvare funnet på MK3 printer"
+msgstr "Nytt opptrykk"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamle filamentet og trykk valghjulet for å laste et nytt."

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2554,7 +2554,7 @@ msgstr "Gjør klar"
 msgid "Set not Ready"
 msgstr "Sett ikke klar"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Opptrykk"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2570,7 +2570,7 @@ msgstr "Ustaw gotowość"
 msgid "Set not Ready"
 msgstr "Cofnij gotowość"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Przedruk"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 lub starszy"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 lub nowszy"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "Oczekiwano wersji %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Anuluj"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Ustawianie Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Wszystko OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Gotowe. Udanego drukowania!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Zawsze"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Otoczenie"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "Obydwa końce osi Z są na szczycie?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Asyst."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Auto bazowanie"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Automatycz"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "Autoładowanie fil."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Unikaj ścierania"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Oś"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Długość osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Wstecz"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Stół"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Grzanie stołu"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Stół OK"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Korekta stołu"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +168,54 @@ msgstr ""
 "Czekam na reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Stół/Grzanie"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Stan pasków"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Test pasków"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Wykryto zanik napięcia. Wznowić druk?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Jasny"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Jasność"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "BŁĄD KOMUNIKACJI"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Kalibracja XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Kalibruj Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +224,13 @@ msgstr ""
 "Naciśnij pokrętło gdy gotowe."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Kalibruję Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,156 +239,156 @@ msgstr ""
 "Naciśnij gdy gotowe."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Bazowanie osi"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Kalibracja"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Kalibracja OK"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Nie można poruszyć wybieraka lub docisku."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "Nie można wykonać akcji, filament jest już załadowany. Wyładuj go najpierw."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "Karta wyjęta"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Zmiana karty SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Wymiana filamentu"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Wymiana udana!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Wymiana udała się?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Kontrola osi X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Kontrola osi Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Kontrola osi Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Kontrola stołu"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Kontrola krańcówek"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Sprawdzanie pliku"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Kontrola hotendu"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Kontrola czujników"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Testy"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "Wyczyść błąd TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Kolor nieprawidłowy"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Od społeczności"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Kont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Wychładzanie"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Skopiować wybrany język?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Zderzeń"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Wykr.zderzeń"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Zderzenie wykryte."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -399,34 +400,34 @@ msgstr ""
 "trybie Normalnym"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Cięcie filamentu"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Nożyk"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Ściemn"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Wyłącz"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Wyłącz silniki"
 
@@ -438,8 +439,8 @@ msgid "Disengaging idler"
 msgstr "Zwalnianie docisku"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -450,7 +451,7 @@ msgstr ""
 "warstwy."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -458,14 +459,14 @@ msgstr ""
 "Chcesz powtórzyć ostatni krok i ponownie ustawić odległość między dyszą, a "
 "stołem?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Gotowe"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "Korekcja-E"
 
@@ -494,13 +495,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Czekam na Użytk."
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "BŁĄD:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Wysuń z MMU"
 
@@ -512,17 +513,17 @@ msgid "Ejecting filament"
 msgstr "Wysuwanie filamentu"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Krańcówka"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Krańcówka nie aktyw."
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Krańcówki"
 
@@ -534,45 +535,45 @@ msgid "Engaging idler"
 msgstr "Uruchamianie docisku"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Ekstruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Ekstruder - info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "Autolad. fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "Zacięcie fil."
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "Koniec fil."
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT JUŻ ZAŁAD."
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NIE WŁĄCZONA"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -581,7 +582,7 @@ msgstr ""
 "Upewnij się, że filament może się poruszać i czy FINDA działa."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -590,65 +591,65 @@ msgstr ""
 "filament może się poruszac i, że FINDA działa."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FIL. ZABLOK."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "Akcja FS"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR NIE WłĄCZ."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR ZBYT WCZEŚN."
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. UTKNĄŁ"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "BŁĄD DZIAŁANIA FW"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Statystyki błędów"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "Błędy MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Fałszywy alarm"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Prędkość went."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Test wentylatora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Sprawdz.went."
 
@@ -677,46 +678,46 @@ msgid "Feeding to nozzle"
 msgstr "Podaję do dyszy"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Końc. filamentu"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Czuj. filam."
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Czy filament wychodzi z dyszy, w prawidłowym kolorze?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Fil. nie załadowany"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Czujnik filamentu"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -725,7 +726,7 @@ msgstr ""
 "Sprawdź, czy filament może się poruszać i czy czujnik działa."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -734,7 +735,7 @@ msgstr ""
 "filament dotarł do czujnika i czy czujnik działa."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -743,42 +744,42 @@ msgstr ""
 "nic nie utknęło w rurce PTFE. Sprawdź czy czujnik odczytuje prawidłowo."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Użyty filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "Plik niekompletny. Kontynuowac?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Kończenie druku"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Kalibr. 1. warstwy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Najpierw włączę selftest w celu sprawdzenia najczęstszych problemów podczas "
 "montażu."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Przepływ"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -787,28 +788,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Przedni went. druku?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Przód [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Przedni/lewy wentyl."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code pocięty dla innej wersji. Kontynuować?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -816,14 +817,14 @@ msgstr ""
 "G-code pocięty na innym poziomie. Potnij model ponownie. Druk anulowany."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code pocięty dla innej drukarki. Kontynuować?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -832,12 +833,12 @@ msgstr ""
 "anulowany."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code pocięty dla nowszego firmware. Kontynuować?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -845,35 +846,35 @@ msgstr ""
 "G-code pocięty dla nowszego firmware. Zaktualizuj firmware. Druk anulowany."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "Ustawienia HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Grzałka/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Grzanie..."
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Grzanie wyłączone przez wył. czasowy."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Grzanie zakończone."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -883,7 +884,7 @@ msgstr ""
 "kalibrację osi Z, po której możesz rozpocząć drukowanie."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -892,8 +893,8 @@ msgstr ""
 "ustawieniami?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Wysoka wyd"
 
@@ -904,49 +905,49 @@ msgid "Homing"
 msgstr "Bazowanie"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 "Hotend rozgrzany do 280°C! Dysza wymieniona i dokręcona wg specyfikacji?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Went. hotendu:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Przeprowadzę teraz kalibrację XYZ. Zajmie to do 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Przeprowadzę teraz kalibracje Z."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "DOCISK NIE BAZUJE"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "DOCISK NIE RUSZA SIĘ"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "SPRAWDŹ FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "BŁĘDNE NARZĘDZIE"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -955,27 +956,27 @@ msgstr ""
 "Ustawienia - Ustawienia HW - Płyty stalowe."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Poprawianie punktu kalibracji stołu"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Ekran informacyjny"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Inic. karty SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Wprowadź filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -984,278 +985,280 @@ msgstr ""
 "pokrętło."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Wewnętrzny błąd działania. Zresetuj MMU lub zaktualizuj firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Filament jest załadowany?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Czy płyta stalowa jest na stole?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteracja"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Ostatni wydruk"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Ostatnie błędy druku"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Lewa"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Lewy went. hotendu?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Lewo [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Poziom jasn."
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Poziom ciem."
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Korekcja liniowa"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Ustawianie Live Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Załaduj Wszystkie"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Ładowanie fil."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Załaduj do dyszy"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Test ładowania"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Ładowanie koloru"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Ładowanie filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Luźne koło pasowe"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Głośny"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW WYMAGA AKTUAL"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Błąd wewnętrzny Firmware MMU. Proszę zresetuj MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "Tryb MMU"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NIE ODPOWIADA"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Ponawianie: Nagrzewanie..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST NIEUD."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "Błędy MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "Błędy ład. MMU"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU nie odpowiada prawidłowo. Sprawdź okablowanie i złącza."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU nie reaguje. Sprawdź okablowanie i złącza."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU połączone"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Kor. magnesów"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Menu główne"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Zmierz. skos"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Określanie wysokości odniesienia punktu kalibracyjnego"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Siatka"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Poziomowanie stołu"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Tryb"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Trwa zmiana trybu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Więcej szczegółów online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Silnik"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Ruch osi X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Ruch osi Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Ruch osi Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Ruch osi"
 
@@ -1266,94 +1269,95 @@ msgid "Moving selector"
 msgstr "Ruch wybieraka"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Dostępna jest nowa wersja firmware:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Nie"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Brak karty SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Brak ruchu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Brak"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Nie podłączono"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Nie kręci się"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Kalibruję odległość między końcówką dyszy, a powierzchnią druku."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nagrzewam dyszę dla PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Teraz zdejmij wydruk testowy ze stołu."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Dysza"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Wymiana dyszy"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Śr. dyszy"
 
@@ -1364,82 +1368,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Wył"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Znaleziono stare ustawienia. Zostaną przywrócone domyślne ustawienia PID, "
 "Ekroków, itp."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "Wł"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "1-raz"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUZA BŁĄD TERMICZNY"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "Kalibracja PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "Kal. PID zakończona"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "Kalibracja PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "Grzanie sondy PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "Kalib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "Kalibracja PINDA nieudana"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1448,7 +1452,7 @@ msgstr ""
 " -> Kalib. PINDA"
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "RADEŁKO NIE RUSZA"
 
@@ -1459,13 +1463,13 @@ msgid "Parking selector"
 msgstr "Parkowanie wybieraka"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Wstrzym. wydruku"
 
@@ -1476,7 +1480,7 @@ msgid "Performing cut"
 msgstr "Odcinanie"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1485,7 +1489,7 @@ msgstr ""
 "punktow. Jeśli dysza zahaczy o papier, natychmiast wyłącz drukarkę."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1494,33 +1498,33 @@ msgstr ""
 "Asystenta przez restart drukarki."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Sprawdź połączenie czujnika IR, wyładuj filament, jesli załadowany."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Sprawdź:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Oczyść powierzchnię druku i naciśnij pokrętło."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Dla prawidłowej kalibracji należy oczyścić dyszę. Potwierdź guzikiem."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Wsuń filament do ekstrudera i naciśnij pokrętło, aby go załadować."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1529,104 +1533,104 @@ msgstr ""
 "załadować."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Najpierw załaduj filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Odciągnij dźwignię dociskową ekstrudera i ręcznie usuń filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Umieść płytę stalową na podgrzewanym stole."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Naciśnij pokrętło aby rozładować filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Wyciągnij filament teraz"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Najpierw usuń zabezpieczenia transportowe."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Usuń płytę stalową z podgrzewanego stołu."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Najpierw uruchom kalibrację XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Najpierw wyładuj filament, następnie powtórz czynność."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Proszę zaktualizować"
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Proszę czekać"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Zaniki zasil."
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Grzanie"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Nagrzej dyszę!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Nagrzewanie dyszy. Proszę czekać."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Nagrzew. do cięcia"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Nagrzew. do wysun."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Grzanie do załad."
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Nagrzew. do rozład."
 
@@ -1637,48 +1641,48 @@ msgid "Preparing blade"
 msgstr "Przygot. ostrza"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Wciśnij pokrętło"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Wciśnij pokrętło aby rozgrzać dyszę i kontynuować."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Druk przerwany"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Went. druku:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Druk z karty SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Druk wstrzymany"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Czas druku"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Adr. IP drukarki:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1687,12 +1691,12 @@ msgstr ""
 "Pierwsze kroki."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Średnica dyszy różni się od tej w G-code. Kontynuować?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1701,7 +1705,7 @@ msgstr ""
 "anulowany."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Silnik koła radełkowanego utknął. Upewnij się, że koło może się poruszać i "
@@ -1714,32 +1718,32 @@ msgid "Pushing filament"
 msgstr "Wsuwanie filamentu"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "KOLEJKA PEŁNA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Tył [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Wznawianie druku"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Zmień nazwę"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1748,24 +1752,24 @@ msgstr ""
 " pod względem indeksu narzędzia z poza zakresu (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Reset kalibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Wznowić druk"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Wznawianie druku"
 
@@ -1776,7 +1780,7 @@ msgid "Retract from FINDA"
 msgstr "Wycofanie z FINDY"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Ponów"
 
@@ -1787,17 +1791,17 @@ msgid "Returning selector"
 msgstr "Powrót wybieraka"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Prawa"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Prawo [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1806,39 +1810,39 @@ msgstr ""
 "Kontynuować?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "Karta SD"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "WYBIERAK NIE BAZUJE"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "WYBIERAK NIE RUSZA"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "ZATRZYMANO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Szukam punktu kalib. na stole"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Wybierz"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1847,25 +1851,25 @@ msgstr ""
 "ekranowym."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Wybierz filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Wybór języka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Wybierz temperaturę grzania dyszy odpowiednią dla materiału."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Wybierz temperaturę, która odpowiada Twojemu filamentowi."
 
@@ -1876,74 +1880,74 @@ msgid "Selecting fil. slot"
 msgstr "Wyb. kanału fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Selftest startuje"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Błąd selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Selftest nieudany"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Zostanie uruchomiony Selftest aby dokładnie skalibrować punkt bazowy bez "
 "krańcówek."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Info o sensorach"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Czujnik sprawdzony, wyciągnij filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Ustaw temperaturę:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Ustawienia"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Znaczny skos"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Płyta"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1956,23 +1960,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Pokaż krańcówki"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Cichy"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Lekki skos"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1981,126 +1985,126 @@ msgstr ""
 "100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Wykryto problem - wymuszono poziomowanie osi Z."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Sort."
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Sortowanie plików"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Dźwięk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Prędkość"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Kręci się"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Potrzebna jest stabilna temperatura otoczenia 21-26C i stabilne podłoże."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statystyki"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Cichy"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Płyty stalowe"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Przerwanie druku"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Restr."
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Wsparcie"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Zamieniono"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIA TERMICZNA"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "BŁĄD STEROW. TMC"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "RESET STEROW. TMC"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "ZWARCIE STEROW. TMC"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "PRZEGRZANIE TMC"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ZA NIS. NAPIĘCIE TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2109,27 +2113,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Model termiczny nie został jeszcze skalib."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Temperatury"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Testowanie filamentu"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2137,7 +2141,7 @@ msgstr ""
 "ruchu."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2145,7 +2149,7 @@ msgstr ""
 " ruchu."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2156,7 +2160,7 @@ msgstr ""
 " Kalibracja)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2165,63 +2169,63 @@ msgstr ""
 "Pierwsze Kroki."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Czas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Wył. czas."
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Suma"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Suma błędów"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Zużycie filamentu"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Łączny czas druku"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Dostrój"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "WYŁADUJ RĘCZNIE"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Wyładuj"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Wyładuj filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Wyładowuję filament"
 
@@ -2238,23 +2242,23 @@ msgid "Unloading to pulley"
 msgstr "Wyład. do radełka"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Niepowodzenie sprawdzenia, wyciągnij filament i spróbuj ponownie."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Napięcia"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "UWAGA TMC ZA GORĄCY"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2267,197 +2271,191 @@ msgstr ""
 "trybie Stealth"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Czekam na użytk. ..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Czekam na wychłodzenie sondy PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Oczekiwanie na wychłodzenie dyszy i stołu"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Ostrzeź"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Ostrzeżenie: typ drukarki i płyta główna uległy zmianie."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Ostrzeżenie: płyta główna uległa zmianie."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Ostrzeżenie: rodzaj drukarki uległ zmianie."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Wyładowanie fil. udane?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Błąd połączenia"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Asystent"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "Korekcja-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "Szczegóły kal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Kalibracja XYZ pomyślna. Skos będzie automatycznie korygowany."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibracja XYZ prawidłowa. Osie X/Y lekko skośne. Dobra robota!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibr. XYZ niedokładna. Przednie punkty kalibr. nieosiągalne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibracja XYZ niedokładna. Prawy przedni punkt nieosiągalny."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibracja XYZ nieudana. Nie znaleziono punktów kalibracyjnych."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Kalibracja XYZ nieudana. Przednie punkty kalibracji nieosiągalne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 "Kalibracja XYZ nieudana. Sprawdź przyczyny i rozwiązania w podręczniku."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Kalibracja XYZ nieudana. Prawy przedni punkt nieosiągalny."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibracja XYZ ok. Osie X/Y są prostopadłe. Gratulacje!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Dystans od 0 w osi Y"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Korekcja-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Tak"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Zawsze możesz uruchomić Asystenta ponownie przez Kalibracja -> Asystent."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Korekcja-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Ilość Pomiarów"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] przesuń.punktu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "i naciśnij pokrętło"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "aby załadow. fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "aby wyład. filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "nieznane"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "Stan nieznany"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Odświeżać"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "Zaniki zas. MMU"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT WYSUNIĘTY"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2466,12 +2464,12 @@ msgstr ""
 "Sprawdź czujniki i okablowanie."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "ŁAD DO EXTR NIEUDANE"
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2480,28 +2478,28 @@ msgstr ""
 "razie potrzeby dostrój kalibrację czujnika."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU BŁĄD"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Wymiany materiałów"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Usuń wyrzucony filament z przodu MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2510,7 +2508,7 @@ msgstr ""
 "się, że w selektorze nie ma filamentu i że FINDA działa prawidłowo."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2518,55 +2516,47 @@ msgstr ""
 "wersji 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Załaduj do MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "Wykryto firmware MK3 w drukarce MK3S"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "Wykryto firmware MK3S w drukarce MK3"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "NIEZNANY BŁĄD"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Pojawił się nieoczekiwany błąd."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Wysuń"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "ZMIANA FILAMENTU"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Załaduj"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Załaduj nowy filament lub wyładuj poprzedni."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Czułość"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Poziomowanie stołu nieudane. Proszę uruchomić kalibrację Z."
 
@@ -2580,10 +2570,19 @@ msgstr "Ustaw gotowość"
 msgid "Set not Ready"
 msgstr "Cofnij gotowość"
 
-#. MSG_REPRINT c=8
-#: ../../Firmware/ultralcd.cpp:5189
+#. MSG_REPRINT c=7
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Przedruk"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Odświeżać"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "Wykryto firmware MK3 w drukarce MK3S"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "Wykryto firmware MK3S w drukarce MK3"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Wyciągnij poprzedni filament i naciśnij pokrętło aby załadować nowy."

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2580,7 +2580,7 @@ msgstr "Ustaw gotowość"
 msgid "Set not Ready"
 msgstr "Cofnij gotowość"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=8
 #: ../../Firmware/ultralcd.cpp:5189
 msgid "Reprint"
 msgstr "Przedruk"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 lub starszy"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 lub nowszy"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "Oczekiwano wersji %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Anuluj"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Ustawianie Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Wszystko OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Gotowe. Udanego drukowania!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Zawsze"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Otoczenie"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "Obydwa końce osi Z są na szczycie?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Asyst."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Auto bazowanie"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Automatycz"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "Autoładowanie fil."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,281 +113,281 @@ msgid "Avoiding grind"
 msgstr "Unikaj ścierania"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Oś"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Długość osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Wstecz"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Stół"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Grzanie stołu"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Stół OK"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Korekta stołu"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
 msgstr ""
-"Poziomowanie stołu nieudane. Sensor nie aktywował się. Zanieczysz. dysza? "
-"Czekam na reset."
+"Poziomowanie stołu nieudane. Sensor nie aktywował się. Zanieczysz. dysza? Czekam na "
+"reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Stół/Grzanie"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Stan pasków"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Test pasków"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Wykryto zanik napięcia. Wznowić druk?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Jasny"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Jasność"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "BŁĄD KOMUNIKACJI"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Kalibracja XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Kalibruj Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
-"Kalibracja XYZ. Przekręć pokrętło, aby przesunąć oś Z do górnych krańcówek. "
-"Naciśnij pokrętło gdy gotowe."
+"Kalibracja XYZ. Przekręć pokrętło, aby przesunąć oś Z do górnych "
+"krańcówek. Naciśnij pokrętło gdy gotowe."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Kalibruję Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
-"Kalibracja Z. Przekręć pokrętło, aby przesunąć oś Z do górnych krańcówek. "
-"Naciśnij gdy gotowe."
+"Kalibracja Z. Przekręć pokrętło, aby przesunąć oś Z do górnych "
+"krańcówek. Naciśnij gdy gotowe."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Bazowanie osi"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Kalibracja"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Kalibracja OK"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Nie można poruszyć wybieraka lub docisku."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "Nie można wykonać akcji, filament jest już załadowany. Wyładuj go najpierw."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "Karta wyjęta"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Zmiana karty SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Wymiana filamentu"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Wymiana udana!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Wymiana udała się?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Kontrola osi X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Kontrola osi Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Kontrola osi Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Kontrola stołu"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Kontrola krańcówek"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Sprawdzanie pliku"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Kontrola hotendu"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Kontrola czujników"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Testy"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "Wyczyść błąd TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Kolor nieprawidłowy"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Od społeczności"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Kont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Wychładzanie"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Skopiować wybrany język?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Zderzeń"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Wykr.zderzeń"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Zderzenie wykryte."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -400,34 +399,34 @@ msgstr ""
 "trybie Normalnym"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Cięcie filamentu"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Nożyk"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Ściemn"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Wyłącz"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Wyłącz silniki"
 
@@ -439,8 +438,8 @@ msgid "Disengaging idler"
 msgstr "Zwalnianie docisku"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -451,7 +450,7 @@ msgstr ""
 "warstwy."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -459,14 +458,14 @@ msgstr ""
 "Chcesz powtórzyć ostatni krok i ponownie ustawić odległość między dyszą, a "
 "stołem?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Gotowe"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "Korekcja-E"
 
@@ -495,13 +494,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Czekam na Użytk."
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "BŁĄD:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Wysuń z MMU"
 
@@ -513,17 +512,17 @@ msgid "Ejecting filament"
 msgstr "Wysuwanie filamentu"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Krańcówka"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Krańcówka nie aktyw."
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Krańcówki"
 
@@ -535,45 +534,45 @@ msgid "Engaging idler"
 msgstr "Uruchamianie docisku"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Ekstruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Ekstruder - info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "Autolad. fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "Zacięcie fil."
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "Koniec fil."
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAMENT JUŻ ZAŁAD."
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NIE WŁĄCZONA"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -582,7 +581,7 @@ msgstr ""
 "Upewnij się, że filament może się poruszać i czy FINDA działa."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -591,65 +590,65 @@ msgstr ""
 "filament może się poruszac i, że FINDA działa."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FIL. ZABLOK."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "Akcja FS"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR NIE WłĄCZ."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR ZBYT WCZEŚN."
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. UTKNĄŁ"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "BŁĄD DZIAŁANIA FW"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Statystyki błędów"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "Błędy MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Fałszywy alarm"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Prędkość went."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Test wentylatora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Sprawdz.went."
 
@@ -678,46 +677,46 @@ msgid "Feeding to nozzle"
 msgstr "Podaję do dyszy"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Końc. filamentu"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Czuj. filam."
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Czy filament wychodzi z dyszy, w prawidłowym kolorze?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Fil. nie załadowany"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Czujnik filamentu"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -726,7 +725,7 @@ msgstr ""
 "Sprawdź, czy filament może się poruszać i czy czujnik działa."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -735,7 +734,7 @@ msgstr ""
 "filament dotarł do czujnika i czy czujnik działa."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -744,42 +743,42 @@ msgstr ""
 "nic nie utknęło w rurce PTFE. Sprawdź czy czujnik odczytuje prawidłowo."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Użyty filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "Plik niekompletny. Kontynuowac?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Kończenie druku"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Kalibr. 1. warstwy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Najpierw włączę selftest w celu sprawdzenia najczęstszych problemów podczas "
 "montażu."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Przepływ"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -788,28 +787,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Przedni went. druku?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Przód [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Przedni/lewy wentyl."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code pocięty dla innej wersji. Kontynuować?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -817,14 +816,14 @@ msgstr ""
 "G-code pocięty na innym poziomie. Potnij model ponownie. Druk anulowany."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code pocięty dla innej drukarki. Kontynuować?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -833,48 +832,48 @@ msgstr ""
 "anulowany."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code pocięty dla nowszego firmware. Kontynuować?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
-msgstr ""
-"G-code pocięty dla nowszego firmware. Zaktualizuj firmware. Druk anulowany."
+msgstr "G-code pocięty dla nowszego firmware. Zaktualizuj firmware. "
+"Druk anulowany."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "Ustawienia HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Grzałka/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Grzanie..."
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Grzanie wyłączone przez wył. czasowy."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Grzanie zakończone."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -884,7 +883,7 @@ msgstr ""
 "kalibrację osi Z, po której możesz rozpocząć drukowanie."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -893,8 +892,8 @@ msgstr ""
 "ustawieniami?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Wysoka wyd"
 
@@ -905,49 +904,49 @@ msgid "Homing"
 msgstr "Bazowanie"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 "Hotend rozgrzany do 280°C! Dysza wymieniona i dokręcona wg specyfikacji?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Went. hotendu:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Przeprowadzę teraz kalibrację XYZ. Zajmie to do 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Przeprowadzę teraz kalibracje Z."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "DOCISK NIE BAZUJE"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "DOCISK NIE RUSZA SIĘ"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "SPRAWDŹ FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "BŁĘDNE NARZĘDZIE"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -956,27 +955,27 @@ msgstr ""
 "Ustawienia - Ustawienia HW - Płyty stalowe."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Poprawianie punktu kalibracji stołu"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Ekran informacyjny"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Inic. karty SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Wprowadź filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -985,280 +984,278 @@ msgstr ""
 "pokrętło."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Wewnętrzny błąd działania. Zresetuj MMU lub zaktualizuj firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Filament jest załadowany?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Czy płyta stalowa jest na stole?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Iteracja"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Ostatni wydruk"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Ostatnie błędy druku"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Lewa"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Lewy went. hotendu?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Lewo [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Poziom jasn."
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Poziom ciem."
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Korekcja liniowa"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Ustawianie Live Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Załaduj Wszystkie"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Ładowanie fil."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Załaduj do dyszy"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Test ładowania"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Ładowanie koloru"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Ładowanie filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Luźne koło pasowe"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Głośny"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW WYMAGA AKTUAL"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Błąd wewnętrzny Firmware MMU. Proszę zresetuj MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "Tryb MMU"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NIE ODPOWIADA"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Ponawianie: Nagrzewanie..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST NIEUD."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "Błędy MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "Błędy ład. MMU"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU nie odpowiada prawidłowo. Sprawdź okablowanie i złącza."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU nie reaguje. Sprawdź okablowanie i złącza."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU połączone"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Kor. magnesów"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Menu główne"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Zmierz. skos"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Określanie wysokości odniesienia punktu kalibracyjnego"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Siatka"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Poziomowanie stołu"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Tryb"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Trwa zmiana trybu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Więcej szczegółów online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Silnik"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Ruch osi X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Ruch osi Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Ruch osi Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Ruch osi"
 
@@ -1269,95 +1266,94 @@ msgid "Moving selector"
 msgstr "Ruch wybieraka"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Dostępna jest nowa wersja firmware:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Nie"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Brak karty SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Brak ruchu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Brak"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Nie podłączono"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Nie kręci się"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Kalibruję odległość między końcówką dyszy, a powierzchnią druku."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nagrzewam dyszę dla PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Teraz zdejmij wydruk testowy ze stołu."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Dysza"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Wymiana dyszy"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Śr. dyszy"
 
@@ -1368,82 +1364,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Wył"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Znaleziono stare ustawienia. Zostaną przywrócone domyślne ustawienia PID, "
 "Ekroków, itp."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "Wł"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "1-raz"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUZA BŁĄD TERMICZNY"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "Kalibracja PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "Kal. PID zakończona"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "Kalibracja PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "Grzanie sondy PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "Kalib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "Kalibracja PINDA nieudana"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1452,7 +1448,7 @@ msgstr ""
 " -> Kalib. PINDA"
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "RADEŁKO NIE RUSZA"
 
@@ -1463,13 +1459,13 @@ msgid "Parking selector"
 msgstr "Parkowanie wybieraka"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Wstrzym. wydruku"
 
@@ -1480,7 +1476,7 @@ msgid "Performing cut"
 msgstr "Odcinanie"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1489,7 +1485,7 @@ msgstr ""
 "punktow. Jeśli dysza zahaczy o papier, natychmiast wyłącz drukarkę."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1498,33 +1494,33 @@ msgstr ""
 "Asystenta przez restart drukarki."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Sprawdź połączenie czujnika IR, wyładuj filament, jesli załadowany."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Sprawdź:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Oczyść powierzchnię druku i naciśnij pokrętło."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Dla prawidłowej kalibracji należy oczyścić dyszę. Potwierdź guzikiem."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Wsuń filament do ekstrudera i naciśnij pokrętło, aby go załadować."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1533,104 +1529,104 @@ msgstr ""
 "załadować."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Najpierw załaduj filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Odciągnij dźwignię dociskową ekstrudera i ręcznie usuń filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Umieść płytę stalową na podgrzewanym stole."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Naciśnij pokrętło aby rozładować filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Wyciągnij filament teraz"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Najpierw usuń zabezpieczenia transportowe."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Usuń płytę stalową z podgrzewanego stołu."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Najpierw uruchom kalibrację XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Najpierw wyładuj filament, następnie powtórz czynność."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Proszę zaktualizować"
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Proszę czekać"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Zaniki zasil."
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Grzanie"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Nagrzej dyszę!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Nagrzewanie dyszy. Proszę czekać."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Nagrzew. do cięcia"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Nagrzew. do wysun."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Grzanie do załad."
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Nagrzew. do rozład."
 
@@ -1641,48 +1637,48 @@ msgid "Preparing blade"
 msgstr "Przygot. ostrza"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Wciśnij pokrętło"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Wciśnij pokrętło aby rozgrzać dyszę i kontynuować."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Druk przerwany"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Went. druku:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Druk z karty SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Druk wstrzymany"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Czas druku"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Adr. IP drukarki:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1691,12 +1687,12 @@ msgstr ""
 "Pierwsze kroki."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Średnica dyszy różni się od tej w G-code. Kontynuować?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1705,7 +1701,7 @@ msgstr ""
 "anulowany."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Silnik koła radełkowanego utknął. Upewnij się, że koło może się poruszać i "
@@ -1718,32 +1714,32 @@ msgid "Pushing filament"
 msgstr "Wsuwanie filamentu"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "KOLEJKA PEŁNA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Tył [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Wznawianie druku"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Zmień nazwę"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1752,24 +1748,24 @@ msgstr ""
 " pod względem indeksu narzędzia z poza zakresu (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Reset kalibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Wznowić druk"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Wznawianie druku"
 
@@ -1780,7 +1776,7 @@ msgid "Retract from FINDA"
 msgstr "Wycofanie z FINDY"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Ponów"
 
@@ -1791,17 +1787,17 @@ msgid "Returning selector"
 msgstr "Powrót wybieraka"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Prawa"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Prawo [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1810,39 +1806,39 @@ msgstr ""
 "Kontynuować?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "Karta SD"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "WYBIERAK NIE BAZUJE"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "WYBIERAK NIE RUSZA"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "ZATRZYMANO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Szukam punktu kalib. na stole"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Wybierz"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1851,25 +1847,25 @@ msgstr ""
 "ekranowym."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Wybierz filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Wybór języka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Wybierz temperaturę grzania dyszy odpowiednią dla materiału."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Wybierz temperaturę, która odpowiada Twojemu filamentowi."
 
@@ -1880,74 +1876,74 @@ msgid "Selecting fil. slot"
 msgstr "Wyb. kanału fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Selftest startuje"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Błąd selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Selftest nieudany"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Zostanie uruchomiony Selftest aby dokładnie skalibrować punkt bazowy bez "
 "krańcówek."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Info o sensorach"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Czujnik sprawdzony, wyciągnij filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Ustaw temperaturę:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Ustawienia"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Znaczny skos"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Płyta"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1960,23 +1956,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Pokaż krańcówki"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Cichy"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Lekki skos"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1985,126 +1981,126 @@ msgstr ""
 "100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Wykryto problem - wymuszono poziomowanie osi Z."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Sort."
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Sortowanie plików"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Dźwięk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Prędkość"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Kręci się"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Potrzebna jest stabilna temperatura otoczenia 21-26C i stabilne podłoże."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statystyki"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Cichy"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Płyty stalowe"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Przerwanie druku"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Restr."
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Wsparcie"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Zamieniono"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIA TERMICZNA"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "BŁĄD STEROW. TMC"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "RESET STEROW. TMC"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "ZWARCIE STEROW. TMC"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "PRZEGRZANIE TMC"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ZA NIS. NAPIĘCIE TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2113,27 +2109,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Model termiczny nie został jeszcze skalib."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Temperatury"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Testowanie filamentu"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2141,7 +2137,7 @@ msgstr ""
 "ruchu."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2149,7 +2145,7 @@ msgstr ""
 " ruchu."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2160,72 +2156,72 @@ msgstr ""
 " Kalibracja)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
 msgstr ""
-"Należy przeprowadzić kalibrację Z. Kieruj się Podręcznikiem: rozdział "
-"Pierwsze Kroki."
+"Należy przeprowadzić kalibrację Z. Kieruj się Podręcznikiem: rozdział Pierwsze"
+" Kroki."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Czas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Wył. czas."
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Suma"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Suma błędów"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Zużycie filamentu"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Łączny czas druku"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Dostrój"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "WYŁADUJ RĘCZNIE"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Wyładuj"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Wyładuj filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Wyładowuję filament"
 
@@ -2242,23 +2238,23 @@ msgid "Unloading to pulley"
 msgstr "Wyład. do radełka"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Niepowodzenie sprawdzenia, wyciągnij filament i spróbuj ponownie."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Napięcia"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "UWAGA TMC ZA GORĄCY"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2271,191 +2267,199 @@ msgstr ""
 "trybie Stealth"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Czekam na użytk. ..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Czekam na wychłodzenie sondy PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Oczekiwanie na wychłodzenie dyszy i stołu"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Ostrzeź"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Ostrzeżenie: typ drukarki i płyta główna uległy zmianie."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Ostrzeżenie: płyta główna uległa zmianie."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Ostrzeżenie: rodzaj drukarki uległ zmianie."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Wyładowanie fil. udane?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Błąd połączenia"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Asystent"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "Korekcja-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "Szczegóły kal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Kalibracja XYZ pomyślna. Skos będzie automatycznie korygowany."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibracja XYZ prawidłowa. Osie X/Y lekko skośne. Dobra robota!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibr. XYZ niedokładna. Przednie punkty kalibr. nieosiągalne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibracja XYZ niedokładna. Prawy przedni punkt nieosiągalny."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibracja XYZ nieudana. Nie znaleziono punktów kalibracyjnych."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
-msgstr "Kalibracja XYZ nieudana. Przednie punkty kalibracji nieosiągalne."
+msgstr ""
+"Kalibracja XYZ nieudana. Przednie punkty kalibracji nieosiągalne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 "Kalibracja XYZ nieudana. Sprawdź przyczyny i rozwiązania w podręczniku."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
-msgstr "Kalibracja XYZ nieudana. Prawy przedni punkt nieosiągalny."
+msgstr ""
+"Kalibracja XYZ nieudana. Prawy przedni punkt nieosiągalny."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibracja XYZ ok. Osie X/Y są prostopadłe. Gratulacje!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Dystans od 0 w osi Y"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Korekcja-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Tak"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Zawsze możesz uruchomić Asystenta ponownie przez Kalibracja -> Asystent."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Korekcja-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Ilość Pomiarów"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] przesuń.punktu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "i naciśnij pokrętło"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "aby załadow. fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "aby wyład. filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "nieznane"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "Stan nieznany"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Odświeżać"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "Zaniki zas. MMU"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT WYSUNIĘTY"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2464,99 +2468,107 @@ msgstr ""
 "Sprawdź czujniki i okablowanie."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "ŁAD DO EXTR NIEUDANE"
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
 msgstr ""
-"Ładowanie do ekstrudera nieudane. Sprawdź kształt końcówki filamentu. W "
-"razie potrzeby dostrój kalibrację czujnika."
+"Ładowanie do ekstrudera nieudane. Sprawdź kształt końcówki "
+"filamentu. W razie potrzeby dostrój kalibrację czujnika."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU BŁĄD"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Wymiany materiałów"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Usuń wyrzucony filament z przodu MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
 msgstr ""
-"Wybierak nie może się poruszyć, bo czujnik FINDA wykrył filament. Upewnij "
-"się, że w selektorze nie ma filamentu i że FINDA działa prawidłowo."
+"Wybierak nie może się poruszyć, bo czujnik FINDA wykrył filament. "
+"Upewnij się, że w selektorze nie ma filamentu i że FINDA działa prawidłowo."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
-"Wersja firmware MMU jest niezgodna z firmware drukarki. Zaktualizuj MMU do "
-"wersji 3.0.1."
+"Wersja firmware MMU jest niezgodna z firmware drukarki. Zaktualizuj "
+"MMU do wersji 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Załaduj do MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "Wykryto firmware MK3 w drukarce MK3S"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "Wykryto firmware MK3S w drukarce MK3"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "NIEZNANY BŁĄD"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Pojawił się nieoczekiwany błąd."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Wysuń"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "ZMIANA FILAMENTU"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Załaduj"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Załaduj nowy filament lub wyładuj poprzedni."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Czułość"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Poziomowanie stołu nieudane. Proszę uruchomić kalibrację Z."
 
@@ -2574,15 +2586,6 @@ msgstr "Cofnij gotowość"
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Przedruk"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Odświeżać"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "Wykryto firmware MK3 w drukarce MK3S"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "Wykryto firmware MK3S w drukarce MK3"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Wyciągnij poprzedni filament i naciśnij pokrętło aby załadować nowy."

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2580,6 +2580,11 @@ msgstr "Ustaw gotowość"
 msgid "Set not Ready"
 msgstr "Cofnij gotowość"
 
+#. MSG_REPRINT c=7
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Przedruk"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Wyciągnij poprzedni filament i naciśnij pokrętło aby załadować nowy."
 

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2591,7 +2591,7 @@ msgstr "Print. nu pregătit"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Retipărire"
+msgstr "Repetă print"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 / mai vechi"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 / mai nou"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "nivel %s așteptat"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Anulează"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Ajustare Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Totul OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Totul este OK. Distracție plăcută!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Mereu"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Ambiental"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "Este axa Z aliniată sus?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Put. auto"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "Înc.auto filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -115,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Avoiding grind"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Axa"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Lungime axă"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Înapoi"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Pat"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Patul se incălzește"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Pat încălzit"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Nivelare pat"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -169,54 +168,54 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Încălzitor/Pat"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Status curele"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Test curele"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Pană de curent. Continuați printul?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Maxim"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Luminozitate ecran"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "EROARE DE COMUNICARE"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Calibrare XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Calibrare Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -225,13 +224,13 @@ msgstr ""
 "butonul când este gata."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Calibrare Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -240,28 +239,28 @@ msgstr ""
 "butonul când este gata."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Calibrare home"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Calibrare"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Calibrare gata"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Select./Idler blocat"
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
@@ -269,128 +268,128 @@ msgstr ""
 "întâi."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "Card scos"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Schimbă card SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Schimbă filamentul"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Schimbare cu succes!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Schimbat corect?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Verificare axa X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Verificare axa Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Verificare axa Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Verificare pat"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Verif. endstop-uri"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Verif. fișier"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Verificare hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Verificare senzori"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Verificări"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "Ștergeți eroare TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Culoare greșită"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "De la comunitate"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Răcire"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Copiază limba selectată?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Coliz."
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Det.coliziune"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Coliziune detectată."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -401,34 +400,34 @@ msgstr ""
 "doar in modul normal"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Taie filamentul"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Cutter"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Minim"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Dezactiv"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Oprire steppere"
 
@@ -440,8 +439,8 @@ msgid "Disengaging idler"
 msgstr "Decuplare idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -451,7 +450,7 @@ msgstr ""
 "manual, capitolul First steps, secțiunea First layer calibration."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -459,14 +458,14 @@ msgstr ""
 "Vreți să repetați ultimul pas pentru a reajusta distanța dintre vârf și "
 "suprafața de print?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Gata"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "E-corecție"
 
@@ -495,13 +494,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Aștept utilizat."
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "EROARE:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Scoateți din MMU"
 
@@ -513,17 +512,17 @@ msgid "Ejecting filament"
 msgstr "Se scoate filamentul"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Endstop"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Endstop neatins"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Endstop-uri"
 
@@ -535,54 +534,54 @@ msgid "Engaging idler"
 msgstr "Cuplare idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Info. extruder"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "Autoload fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "F. blocaj det"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "Fil. epuizat"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAM. DEJA ÎNCĂRCAT"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NU S-A DECLAN."
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
 msgstr ""
-"FINDA nu s-a oprit la descărcare Fil.Încercați descăr. manuală. Asigurați-vă"
-" că FINDA funcționează."
+"FINDA nu s-a oprit la descărcare Fil.Încercați descăr. manuală. Asigurați-vă "
+"că FINDA funcționează."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -591,65 +590,65 @@ msgstr ""
 "mișcă și FINDA funcționează."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. BLOCAT"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "Acțiune FS"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENZ NU S-A DECLAN."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR PREA DEVREME"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. BLOCAT"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "Eroare FW RUNTIME"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Statistici erori"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "Stat. erori MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Detecție eronată"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Viteză vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Test ventilator"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Verif. vent."
 
@@ -678,46 +677,46 @@ msgid "Feeding to nozzle"
 msgstr "Încărcare la vârf"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Epuizări Fil."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Senzor Fil."
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Fil. curge și are culoarea corectă?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Fil. nu e încărcat"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Senz. de filament"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -726,16 +725,16 @@ msgstr ""
 "filamentul se mișcă și senzorul funcționează."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
 msgstr ""
-"Senzorul de filament nu s-a declanșast în timpul încărcării fil. Asigurați-"
-"vă că filamentul a ajuns la fsenzor și senzorul funcționează."
+"Senzorul de filament nu s-a declanșast în timpul încărcării fil. Asigurați-vă"
+" că filamentul a ajuns la fsenzor și senzorul funcționează."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -744,42 +743,42 @@ msgstr ""
 " nu este nimic blocat in tubul PTFE. Verifică dacă senz. funcț. corect."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Filament folosit"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "Fișier incomplet. Continuă oricum?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Finalizare mișcări"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Cal. first layer"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Mai întâi voi rula testele automate pentru a verifica cele mai întâlnite "
 "probleme de asamblare."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Flow"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -788,28 +787,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Vent. print?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Față [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Ventilatoarele sunt"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "Versiune de G-code e incorectă. Continuați?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -818,28 +817,28 @@ msgstr ""
 "anulat."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code pregătit pentru un alt tip de printer. Continuați?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
 msgstr ""
-"G-code pregătit pentru un alt tip de printer. Vă rugăm să pregătiți modelul "
-"din nou. Print anulat."
+"G-code pregătit pentru un alt tip de printer. Vă rugăm să pregătiți modelul din"
+" nou. Print anulat."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code pregătit pentru firmware mai nou. Continuați?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -848,35 +847,35 @@ msgstr ""
 "Print anulat."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "Setup HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Încălzitor/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Încălzire"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Încălzirea dezactivată de timer-ul de siguranță"
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Încălzirea gata."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -887,7 +886,7 @@ msgstr ""
 "printezi."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -896,8 +895,8 @@ msgstr ""
 "automate și calibrările?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Put. max"
 
@@ -908,48 +907,48 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend la 280C! Vârf schimbat și strâns conf. specificației?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Vent. hotend:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Voi rula calibrarea XYZ acum. Va dura până la 24 de min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Voi rula calibrarea Z acum."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "EROARE HOME IDLER"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "IDLER NU SE MIȘCĂ"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "INSPECTEAZĂ FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "FILAMENT INVALID"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -958,309 +957,306 @@ msgstr ""
 "- Suprafețe print."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Îmbunătățirea punctului de calibrare al patului"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Ecran informații"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Init. card SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Încarcă filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Înfige filamentul (nu-l încărca) in extruder și apasă butonul."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
-"ERR internă de runtime. Încercați să resetați MMU sau să actualizați "
-"firmwarul."
+"ERR internă de runtime. Încercați să resetați MMU sau să actualizați firmwarul."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Este filamentul încărcat?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Este suprafața de print pe pat?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Iterația"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Ultimul print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Erorile ultim. print"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Stânga"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Vent. hotend?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Stânga [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Lum. maxim"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Lum. minim"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Corecție lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Reglare Z live"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Încarcă toate"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Încarcă filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Încarcă la vârf"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Test încărcare"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Încărcare culoare"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Încărcare filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Fulie slăbită"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Tare"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU UPDATE NECESAR"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Eroare internă MMU, vă rog resetați MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "Mod MMU"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NU RĂSPUNDE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU: Restabilirea temperaturii..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU AUTOTEST. EȘUATĂ"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "Erori MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "Err. încărc MMU"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU nu răspunde corect. Verificați cablajul și conectorii."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU nu răspunde. Verificați cablajul si conectorii."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU conectat"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Comp. magneți"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Meniu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Distorsiune"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Măsurare distanță de referință pentru punctul de calib."
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Calibrare mesh"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Schimbare mod în progres..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Mai multe detalii online"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Mișcare X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Mișcare Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Mișcare Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Mișcare axe"
 
@@ -1271,95 +1267,94 @@ msgid "Moving selector"
 msgstr "Mișcare selector"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Vers. de firmware nouă disponibilă:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Nu"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Card SD lipsă"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Fară mișcare."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "N/A"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Nu este conectat"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Nu se rotește"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Acum voi calibra distanța dintre vârf și suprafața patului."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Acum voi preîncălzi extruderul pentru PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Acum înlăturați printul de test de pe suprafața de print."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Vârf"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Schimbare vârf"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Diam. vârf"
 
@@ -1370,80 +1365,80 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Setări vechi detectate. PID, Esteps etc. implicite vor fi setate."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "O dată"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "OPRIT THERMAL ERROR"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "Calibrare PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "Calibrare PID gata"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "Calibrare PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "Încălzire PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "Cal. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "Calibrarea PINDA a eșuat"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1452,7 +1447,7 @@ msgstr ""
 "meniul Setări->Cal. PINDA"
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "PULLEY NU SE MIȘCĂ"
 
@@ -1463,13 +1458,13 @@ msgid "Parking selector"
 msgstr "Parcare selector"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pauză"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Pauză print"
 
@@ -1480,7 +1475,7 @@ msgid "Performing cut"
 msgstr "Efect. tăiere"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1489,7 +1484,7 @@ msgstr ""
 "Dacă vârful prinde hârtia, opriți imediat imprimanta."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1498,35 +1493,35 @@ msgstr ""
 "ul repornind imprimanta."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Verificați senzorul IR, scoateți filamentul dacă există."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Verificați:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Curățați patul și apoi apăsați butonul pentru a continua."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Curățați vârful pentru calibrare. Apăsați butonul când terminați."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
-"Vă rugăm să introduceți filamentul în extruder, apoi apăsați butonul pentru "
-"a-l încărca."
+"Vă rugăm să introduceți filamentul în extruder, apoi apăsați butonul pentru a-l "
+"încărca."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1535,104 +1530,104 @@ msgstr ""
 "pentru a-l încărca."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Vă rugăm încărcați filamentul mai întâi."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Deschideți idler-ul și scoateți filamentul manual."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Așezați suprafața de print pe pat."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Apăsați butonul pentru a scoate filamentul."
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Vă rugăm scoateți filamentul imediat"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Vă rugăm scoateți protecțiile de transport mai întâi."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Vă rugăm îndepărtați suprafața de print de pe pat."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Vă rugăm rulați calibrarea XYZ mai întâi."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vă rugăm mai întâi să scoateți filamentul, apoi încercați din nou."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Vă rugăm actualizați"
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Vă rog așteptați"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Err. alimentare"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Preîncălzire"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Preîncălziți vârful!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Preîncălzire extruder. Vă rugăm așteptați."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Preîncălzire..."
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Preîncălzire..."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Preîncălz. încărcare"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Preîncălz. scoatere"
 
@@ -1643,62 +1638,62 @@ msgid "Preparing blade"
 msgstr "Pregătire lamă"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Apăsați butonul"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Apăsați butonul pentru a preîncălzi extruder-ul și continuați."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Print anulat"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Vent. print:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Printare de pe SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Print oprit"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Durată print"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Adresă IP:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
 msgstr ""
-"Imprimanta nu a fost calibrată. Vă rugăm să urmați manualul, capitolul First"
-" steps, secțiunea Calibration flow."
+"Imprimanta nu a fost calibrată. Vă rugăm să urmați manualul, "
+"capitolul First steps, secțiunea Calibration flow."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diametrul vârfului diferă de cel din G-code. Continuați?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1707,11 +1702,11 @@ msgstr ""
 " setări. Print anulat."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
-"Motorul Pully e blocat. Asigurați-vă că fulia se poate mișca și verificați "
-"cablajul."
+"Motorul Pully e blocat. Asigurați-vă că fulia se poate mișca și "
+"verificați cablajul."
 
 #. MSG_PROGRESS_PUSH_FILAMENT c=20
 #: ../../Firmware/mmu2_progress_converter.cpp:23
@@ -1720,58 +1715,58 @@ msgid "Pushing filament"
 msgstr "Introducere filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "QUEUE PLIN"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Spate [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Recuperare print"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Redenumește"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
 msgstr ""
-"Fil. solicitat nu este disponibil pe acest hardware. Verifică G-codul dacă "
-"folosește filam. în afara intervalului (T0-T4)."
+"Fil. solicitat nu este disponibil pe acest hardware. "
+"Verifică G-codul dacă folosește filam. în afara intervalului (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Reset."
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Reset. calibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Continuă print"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Continuare print"
 
@@ -1782,7 +1777,7 @@ msgid "Retract from FINDA"
 msgstr "Retract de la FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Reîncerc"
 
@@ -1793,17 +1788,17 @@ msgid "Returning selector"
 msgstr "Revenire selector"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Dreapta"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Dreapta [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1812,39 +1807,39 @@ msgstr ""
 " de la început. Continuați?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "Card SD"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "ERR. HOME SELECTOR"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECTOR NU SE MIȘCĂ"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "OPRIT."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Se caută punctele de calibrare"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Selectează"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1853,26 +1848,26 @@ msgstr ""
 "ecran."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Select. filamentul:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Selectați limba"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selectați temperatura de încălzire a extruder-ului pentru materialul ales."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Selectați temp. potrivită pentru materialul curent."
 
@@ -1883,73 +1878,73 @@ msgid "Selecting fil. slot"
 msgstr "Selectare slot fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Testare automată OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Start Autotestare"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Testare automată"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Err. test. automată!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Autotestare eșuată"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Testarea automată va fi rulată pentru a calibra sensorless rehoming-ul."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Info. senzori"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzorul a fost verificat, scoate filamentul."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Setați temperatura:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Setări"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Deform. severă"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Suprafață"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1962,23 +1957,23 @@ msgstr ""
 "%cReset."
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Stare endstop-uri"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Silenț."
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Dist. ușoară"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1987,126 +1982,126 @@ msgstr ""
 "care pot fi sortate este 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "A fost întâmpinată o problemă, calibrarea Z a fost inițiată..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Sortare"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Sortare fișiere..."
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Sunet"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Viteză"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Se rotește"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Temp. ambient. stabilă (21-26C) și o suprafață de lucru rigidă necesare."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statistici"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Silenț."
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Suprafețe print"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Oprire print"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Strict"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Informații"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "inversate"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIE TERMICĂ"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "EROARE DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "RESET DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "DRIVER TMC ÎN SCURT"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "ERR TMC SUPRAÎNCĂLZ."
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERR SUBTENSIUNE TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2115,27 +2110,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Modelul termic nu este înca calibrat."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Temperaturi"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Testare filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2143,7 +2138,7 @@ msgstr ""
 "mișcarea."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2151,7 +2146,7 @@ msgstr ""
 "blocheză mișcarea."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2161,7 +2156,7 @@ msgstr ""
 "înălțimea optimă. Folosiți pozele din handbook (capitolul Calibration)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2170,63 +2165,63 @@ msgstr ""
 "First steps, secțiunea Calibration flow."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Dată"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Total erori"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Filament total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Durata totală print"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Opțiuni"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "DESCĂRCARE MANUALĂ"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Descărc."
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Descarcă filam."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Descărcare filament"
 
@@ -2243,23 +2238,23 @@ msgid "Unloading to pulley"
 msgstr "Descărcare la pulley"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verificarea a eșuat, scoateți filamentul și încercați din nou."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Voltaje"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "TMC SUPRAÎNCĂLZIT"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2272,87 +2267,87 @@ msgstr ""
 "modul silențios"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Se așteaptă..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Se așteaptă răcirea probei PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Se așteaptă răcirea extruderului și a patului"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Avert."
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Atenție: tipul imprimantei și al plăcii de bază s-au schimbat."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Atenție: tipul plăcii de bază s-a schimbat."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Atenție: tipul imprimantei s-a schimbat."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Filamentul a fost scos cu succes?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Eroare cablaj"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "Corecț. X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "Detalii cal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibrarea XYZ în regulă. Distorsiunea va fi corectată automat."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibrarea XYZ în regulă. Axele X/Y sunt distorsionate puțin. Felicitări!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Calibrarea XYZ compromisă. Punctele de calibrare din față nu pot fi atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
@@ -2360,109 +2355,115 @@ msgstr ""
 "atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibrarea XYZ a esuat. Un punct de calibrare a patului nu a fost găsit."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Calibrarea XYZ a eșuat. Punctele de calibrare din față nu pot fi atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrarea XYZ a eșuat. Vă rugăm consultați manualul."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Calibrarea XYZ a eșuat. Punctele de calibrare din față dreapta nu pot fi "
 "atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibrarea XYZ ok. Axele X/Y sunt perpendiculare. Felicitări!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Distanța Y de la min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Corecț. Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Da"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Puteți oricând să reluați Wizard-ul din Calibrare -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Corecț. Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Nr. Z-probe"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] offset origine"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "și apasă butonul"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "a încărca filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "a scoate filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "necunoscut"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "vers. necunoscută"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Reîmprospătează"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "Err. MMU curent"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT EJECTAT"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2471,12 +2472,12 @@ msgstr ""
 " filament. Verificați senzorii și cablajul."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "ERR. ÎNCĂRC. EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2485,28 +2486,28 @@ msgstr ""
 "Ajustați calibrarea senzorului dacă este necesar."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU: EROARE MCU"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Schimburi material"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Scoateți filamentul ejectat din partea din față a MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2516,7 +2517,7 @@ msgstr ""
 "corect."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2524,48 +2525,56 @@ msgstr ""
 "Actualizați la versiunea 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Preîncărcare MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "Firmware MK3 detectat pe imprimanta MK3S"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "Firmware MK3S detectat pe imprimanta MK3"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "EROARE NECUNOSCUTĂ"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "A apărut o eroare neașteptată."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Scoateți"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "SCHIMBARE FILAMENT"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Încarcă"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "M600: Schimbare filament. Încarcă un filament nou sau scoate-l pe cel vechi."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Sensibilitate"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Nivelarea patului a eșuat. Rulează Calibrare Z."
 
@@ -2582,16 +2591,7 @@ msgstr "Print. nu pregătit"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Retiparire"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Reîmprospătează"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "Firmware MK3 detectat pe imprimanta MK3S"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "Firmware MK3S detectat pe imprimanta MK3"
+msgstr "Retipărire"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."
@@ -2609,15 +2609,15 @@ msgstr "Retiparire"
 #~ "The MMU reports its FW version incompatible with the printer's firmware. "
 #~ "Make sure the MMU firmware is up to date."
 #~ msgstr ""
-#~ "Versiunea FW MMU este incompatibilă cu cea a imprimantei. Asigurați-vă că FW"
-#~ " MMU este actualizat."
+#~ "Versiunea FW MMU este incompatibilă cu cea a imprimantei. Asigurați-vă că FW "
+#~ "MMU este actualizat."
 
 #~ msgid ""
 #~ "Unexpected FINDA reading. Ensure no filament is under FINDA and the selector"
 #~ " is free. Check FINDA connection."
 #~ msgstr ""
-#~ "Citire FINDA neașteptată. Asig. că nu este Fil. în FINDA și selector-ul este"
-#~ " liber. Verifică conexiune FINDA."
+#~ "Citire FINDA neașteptată. Asig. că nu este Fil. în FINDA și selector-ul "
+#~ "este liber. Verifică conexiune FINDA."
 
 #~ msgid ""
 #~ "Autoloading filament available only when filament sensor is turned on..."
@@ -2692,14 +2692,12 @@ msgstr "Retiparire"
 #~ "You are using firmware alpha version. This is development version. Using "
 #~ "this version is not recommended and may cause printer damage."
 #~ msgstr ""
-#~ "Utilizați vers.alfa de FW. Acestă este vers. de dezvoltare. Folosirea "
-#~ "aceastei versiuni nu este recomandată și poate cauza deteriorarea "
-#~ "imprimantei"
+#~ "Utilizați vers.alfa de FW. Acestă este vers. de dezvoltare. Folosirea aceastei"
+#~ " versiuni nu este recomandată și poate cauza deteriorarea imprimantei"
 
 #~ msgid ""
 #~ "You are using firmware beta version. This is development version. Using this"
 #~ " version is not recommended and may cause printer damage."
 #~ msgstr ""
 #~ "Utilizați vers. beta de FW. Acesta este vers. de dezvoltare. Folosirea "
-#~ "aceastei versiuni nu este recomandată și poate cauza deteriorarea "
-#~ "imprimantei"
+#~ "aceastei versiuni nu este recomandată și poate cauza deteriorarea imprimantei"

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 / mai vechi"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 / mai nou"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "nivel %s așteptat"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Anulează"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Ajustare Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Totul OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Totul este OK. Distracție plăcută!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Mereu"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Ambiental"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "Este axa Z aliniată sus?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Put. auto"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "Înc.auto filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,52 +115,52 @@ msgid "Avoiding grind"
 msgstr "Avoiding grind"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Axa"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Lungime axă"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Înapoi"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Pat"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Patul se incălzește"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Pat încălzit"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Nivelare pat"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -168,54 +169,54 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Încălzitor/Pat"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Status curele"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Test curele"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Pană de curent. Continuați printul?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Maxim"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Luminozitate ecran"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "EROARE DE COMUNICARE"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Calibrare XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Calibrare Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -224,13 +225,13 @@ msgstr ""
 "butonul când este gata."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Calibrare Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -239,28 +240,28 @@ msgstr ""
 "butonul când este gata."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Calibrare home"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Calibrare"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Calibrare gata"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Select./Idler blocat"
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
@@ -268,128 +269,128 @@ msgstr ""
 "întâi."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "Card scos"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Schimbă card SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Schimbă filamentul"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Schimbare cu succes!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Schimbat corect?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Verificare axa X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Verificare axa Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Verificare axa Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Verificare pat"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Verif. endstop-uri"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Verif. fișier"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Verificare hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Verificare senzori"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Verificări"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "Ștergeți eroare TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Culoare greșită"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "De la comunitate"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Răcire"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Copiază limba selectată?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Coliz."
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Det.coliziune"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Coliziune detectată."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -400,34 +401,34 @@ msgstr ""
 "doar in modul normal"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Taie filamentul"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Cutter"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Minim"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Dezactiv"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Oprire steppere"
 
@@ -439,8 +440,8 @@ msgid "Disengaging idler"
 msgstr "Decuplare idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -450,7 +451,7 @@ msgstr ""
 "manual, capitolul First steps, secțiunea First layer calibration."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -458,14 +459,14 @@ msgstr ""
 "Vreți să repetați ultimul pas pentru a reajusta distanța dintre vârf și "
 "suprafața de print?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Gata"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "E-corecție"
 
@@ -494,13 +495,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Aștept utilizat."
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "EROARE:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Scoateți din MMU"
 
@@ -512,17 +513,17 @@ msgid "Ejecting filament"
 msgstr "Se scoate filamentul"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Endstop"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Endstop neatins"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Endstop-uri"
 
@@ -534,45 +535,45 @@ msgid "Engaging idler"
 msgstr "Cuplare idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Info. extruder"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "Autoload fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "F. blocaj det"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "Fil. epuizat"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FILAM. DEJA ÎNCĂRCAT"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA NU S-A DECLAN."
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -581,7 +582,7 @@ msgstr ""
 " că FINDA funcționează."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -590,65 +591,65 @@ msgstr ""
 "mișcă și FINDA funcționează."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. BLOCAT"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "Acțiune FS"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENZ NU S-A DECLAN."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR PREA DEVREME"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. BLOCAT"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "Eroare FW RUNTIME"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Statistici erori"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "Stat. erori MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Detecție eronată"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Viteză vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Test ventilator"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Verif. vent."
 
@@ -677,46 +678,46 @@ msgid "Feeding to nozzle"
 msgstr "Încărcare la vârf"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Epuizări Fil."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Senzor Fil."
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Fil. curge și are culoarea corectă?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Fil. nu e încărcat"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Senz. de filament"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -725,7 +726,7 @@ msgstr ""
 "filamentul se mișcă și senzorul funcționează."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -734,7 +735,7 @@ msgstr ""
 "vă că filamentul a ajuns la fsenzor și senzorul funcționează."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -743,42 +744,42 @@ msgstr ""
 " nu este nimic blocat in tubul PTFE. Verifică dacă senz. funcț. corect."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Filament folosit"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "Fișier incomplet. Continuă oricum?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Finalizare mișcări"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Cal. first layer"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Mai întâi voi rula testele automate pentru a verifica cele mai întâlnite "
 "probleme de asamblare."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Flow"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -787,28 +788,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Vent. print?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Față [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Ventilatoarele sunt"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "Versiune de G-code e incorectă. Continuați?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -817,14 +818,14 @@ msgstr ""
 "anulat."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code pregătit pentru un alt tip de printer. Continuați?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -833,12 +834,12 @@ msgstr ""
 "din nou. Print anulat."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code pregătit pentru firmware mai nou. Continuați?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -847,35 +848,35 @@ msgstr ""
 "Print anulat."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "Setup HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Încălzitor/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Încălzire"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Încălzirea dezactivată de timer-ul de siguranță"
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Încălzirea gata."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -886,7 +887,7 @@ msgstr ""
 "printezi."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -895,8 +896,8 @@ msgstr ""
 "automate și calibrările?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Put. max"
 
@@ -907,48 +908,48 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend la 280C! Vârf schimbat și strâns conf. specificației?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Vent. hotend:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Voi rula calibrarea XYZ acum. Va dura până la 24 de min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Voi rula calibrarea Z acum."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "EROARE HOME IDLER"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "IDLER NU SE MIȘCĂ"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "INSPECTEAZĂ FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "FILAMENT INVALID"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -957,34 +958,34 @@ msgstr ""
 "- Suprafețe print."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Îmbunătățirea punctului de calibrare al patului"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Ecran informații"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Init. card SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Încarcă filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Înfige filamentul (nu-l încărca) in extruder și apasă butonul."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr ""
@@ -992,272 +993,274 @@ msgstr ""
 "firmwarul."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Este filamentul încărcat?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Este suprafața de print pe pat?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iterația"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Ultimul print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Erorile ultim. print"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Stânga"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Vent. hotend?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Stânga [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Lum. maxim"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Lum. minim"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Corecție lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Reglare Z live"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Încarcă toate"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Încarcă filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Încarcă la vârf"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Test încărcare"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Încărcare culoare"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Încărcare filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Fulie slăbită"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Tare"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU UPDATE NECESAR"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Eroare internă MMU, vă rog resetați MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "Mod MMU"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NU RĂSPUNDE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU: Restabilirea temperaturii..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU AUTOTEST. EȘUATĂ"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "Erori MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "Err. încărc MMU"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU nu răspunde corect. Verificați cablajul și conectorii."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU nu răspunde. Verificați cablajul si conectorii."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU conectat"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Comp. magneți"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Meniu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Distorsiune"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Măsurare distanță de referință pentru punctul de calib."
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Calibrare mesh"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Schimbare mod în progres..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Mai multe detalii online"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Mișcare X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Mișcare Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Mișcare Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Mișcare axe"
 
@@ -1268,94 +1271,95 @@ msgid "Moving selector"
 msgstr "Mișcare selector"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Vers. de firmware nouă disponibilă:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Nu"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Card SD lipsă"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Fară mișcare."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "N/A"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Nu este conectat"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Nu se rotește"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Acum voi calibra distanța dintre vârf și suprafața patului."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Acum voi preîncălzi extruderul pentru PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Acum înlăturați printul de test de pe suprafața de print."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Vârf"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Schimbare vârf"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Diam. vârf"
 
@@ -1366,80 +1370,80 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Setări vechi detectate. PID, Esteps etc. implicite vor fi setate."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "O dată"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "OPRIT THERMAL ERROR"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "Calibrare PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "Calibrare PID gata"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "Calibrare PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "Încălzire PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "Cal. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "Calibrarea PINDA a eșuat"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1448,7 +1452,7 @@ msgstr ""
 "meniul Setări->Cal. PINDA"
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "PULLEY NU SE MIȘCĂ"
 
@@ -1459,13 +1463,13 @@ msgid "Parking selector"
 msgstr "Parcare selector"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pauză"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Pauză print"
 
@@ -1476,7 +1480,7 @@ msgid "Performing cut"
 msgstr "Efect. tăiere"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1485,7 +1489,7 @@ msgstr ""
 "Dacă vârful prinde hârtia, opriți imediat imprimanta."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1494,27 +1498,27 @@ msgstr ""
 "ul repornind imprimanta."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Verificați senzorul IR, scoateți filamentul dacă există."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Verificați:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Curățați patul și apoi apăsați butonul pentru a continua."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Curățați vârful pentru calibrare. Apăsați butonul când terminați."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1522,7 +1526,7 @@ msgstr ""
 "a-l încărca."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1531,104 +1535,104 @@ msgstr ""
 "pentru a-l încărca."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Vă rugăm încărcați filamentul mai întâi."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Deschideți idler-ul și scoateți filamentul manual."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Așezați suprafața de print pe pat."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Apăsați butonul pentru a scoate filamentul."
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Vă rugăm scoateți filamentul imediat"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Vă rugăm scoateți protecțiile de transport mai întâi."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Vă rugăm îndepărtați suprafața de print de pe pat."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Vă rugăm rulați calibrarea XYZ mai întâi."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vă rugăm mai întâi să scoateți filamentul, apoi încercați din nou."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Vă rugăm actualizați"
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Vă rog așteptați"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Err. alimentare"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Preîncălzire"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Preîncălziți vârful!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Preîncălzire extruder. Vă rugăm așteptați."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Preîncălzire..."
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Preîncălzire..."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Preîncălz. încărcare"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Preîncălz. scoatere"
 
@@ -1639,48 +1643,48 @@ msgid "Preparing blade"
 msgstr "Pregătire lamă"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Apăsați butonul"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Apăsați butonul pentru a preîncălzi extruder-ul și continuați."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Print anulat"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Vent. print:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Printare de pe SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Print oprit"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Durată print"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Adresă IP:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1689,12 +1693,12 @@ msgstr ""
 " steps, secțiunea Calibration flow."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diametrul vârfului diferă de cel din G-code. Continuați?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1703,7 +1707,7 @@ msgstr ""
 " setări. Print anulat."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Motorul Pully e blocat. Asigurați-vă că fulia se poate mișca și verificați "
@@ -1716,32 +1720,32 @@ msgid "Pushing filament"
 msgstr "Introducere filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "QUEUE PLIN"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Spate [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Recuperare print"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Redenumește"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1750,24 +1754,24 @@ msgstr ""
 "folosește filam. în afara intervalului (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Reset."
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Reset. calibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Continuă print"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Continuare print"
 
@@ -1778,7 +1782,7 @@ msgid "Retract from FINDA"
 msgstr "Retract de la FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Reîncerc"
 
@@ -1789,17 +1793,17 @@ msgid "Returning selector"
 msgstr "Revenire selector"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Dreapta"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Dreapta [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1808,39 +1812,39 @@ msgstr ""
 " de la început. Continuați?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "Card SD"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "ERR. HOME SELECTOR"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECTOR NU SE MIȘCĂ"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "OPRIT."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Se caută punctele de calibrare"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Selectează"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1849,26 +1853,26 @@ msgstr ""
 "ecran."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Select. filamentul:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Selectați limba"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selectați temperatura de încălzire a extruder-ului pentru materialul ales."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Selectați temp. potrivită pentru materialul curent."
 
@@ -1879,73 +1883,73 @@ msgid "Selecting fil. slot"
 msgstr "Selectare slot fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Testare automată OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Start Autotestare"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Testare automată"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Err. test. automată!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Autotestare eșuată"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Testarea automată va fi rulată pentru a calibra sensorless rehoming-ul."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Info. senzori"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzorul a fost verificat, scoate filamentul."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Setați temperatura:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Setări"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Deform. severă"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Suprafață"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1958,23 +1962,23 @@ msgstr ""
 "%cReset."
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Stare endstop-uri"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Silenț."
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Dist. ușoară"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1983,126 +1987,126 @@ msgstr ""
 "care pot fi sortate este 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "A fost întâmpinată o problemă, calibrarea Z a fost inițiată..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Sortare"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Sortare fișiere..."
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Sunet"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Viteză"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Se rotește"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Temp. ambient. stabilă (21-26C) și o suprafață de lucru rigidă necesare."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statistici"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Silenț."
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Suprafețe print"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Oprire print"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Strict"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Informații"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "inversate"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIE TERMICĂ"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "EROARE DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "RESET DRIVER TMC"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "DRIVER TMC ÎN SCURT"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "ERR TMC SUPRAÎNCĂLZ."
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERR SUBTENSIUNE TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2111,27 +2115,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Modelul termic nu este înca calibrat."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Temperaturi"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Testare filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2139,7 +2143,7 @@ msgstr ""
 "mișcarea."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2147,7 +2151,7 @@ msgstr ""
 "blocheză mișcarea."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2157,7 +2161,7 @@ msgstr ""
 "înălțimea optimă. Folosiți pozele din handbook (capitolul Calibration)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2166,63 +2170,63 @@ msgstr ""
 "First steps, secțiunea Calibration flow."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Dată"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Total erori"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Filament total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Durata totală print"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Opțiuni"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "DESCĂRCARE MANUALĂ"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Descărc."
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Descarcă filam."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Descărcare filament"
 
@@ -2239,23 +2243,23 @@ msgid "Unloading to pulley"
 msgstr "Descărcare la pulley"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verificarea a eșuat, scoateți filamentul și încercați din nou."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Voltaje"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "TMC SUPRAÎNCĂLZIT"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2268,87 +2272,87 @@ msgstr ""
 "modul silențios"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Se așteaptă..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Se așteaptă răcirea probei PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Se așteaptă răcirea extruderului și a patului"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Avert."
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Atenție: tipul imprimantei și al plăcii de bază s-au schimbat."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Atenție: tipul plăcii de bază s-a schimbat."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Atenție: tipul imprimantei s-a schimbat."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Filamentul a fost scos cu succes?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Eroare cablaj"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "Corecț. X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "Detalii cal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibrarea XYZ în regulă. Distorsiunea va fi corectată automat."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibrarea XYZ în regulă. Axele X/Y sunt distorsionate puțin. Felicitări!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Calibrarea XYZ compromisă. Punctele de calibrare din față nu pot fi atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
@@ -2356,115 +2360,109 @@ msgstr ""
 "atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibrarea XYZ a esuat. Un punct de calibrare a patului nu a fost găsit."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Calibrarea XYZ a eșuat. Punctele de calibrare din față nu pot fi atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrarea XYZ a eșuat. Vă rugăm consultați manualul."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Calibrarea XYZ a eșuat. Punctele de calibrare din față dreapta nu pot fi "
 "atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibrarea XYZ ok. Axele X/Y sunt perpendiculare. Felicitări!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Distanța Y de la min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Corecț. Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Da"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Puteți oricând să reluați Wizard-ul din Calibrare -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Corecț. Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Nr. Z-probe"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] offset origine"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "și apasă butonul"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "a încărca filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "a scoate filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "necunoscut"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "vers. necunoscută"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Reîmprospătează"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "Err. MMU curent"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT EJECTAT"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2473,12 +2471,12 @@ msgstr ""
 " filament. Verificați senzorii și cablajul."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "ERR. ÎNCĂRC. EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2487,28 +2485,28 @@ msgstr ""
 "Ajustați calibrarea senzorului dacă este necesar."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU: EROARE MCU"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Schimburi material"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Scoateți filamentul ejectat din partea din față a MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2518,7 +2516,7 @@ msgstr ""
 "corect."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2526,56 +2524,48 @@ msgstr ""
 "Actualizați la versiunea 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Preîncărcare MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "Firmware MK3 detectat pe imprimanta MK3S"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "Firmware MK3S detectat pe imprimanta MK3"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "EROARE NECUNOSCUTĂ"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "A apărut o eroare neașteptată."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Scoateți"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "SCHIMBARE FILAMENT"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Încarcă"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 "M600: Schimbare filament. Încarcă un filament nou sau scoate-l pe cel vechi."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Sensibilitate"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Nivelarea patului a eșuat. Rulează Calibrare Z."
 
@@ -2589,10 +2579,19 @@ msgstr "Printer pregătit"
 msgid "Set not Ready"
 msgstr "Print. nu pregătit"
 
-#. MSG_REPRINT c=10
-#: ../../Firmware/ultralcd.cpp:5189
+#. MSG_REPRINT c=7
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Retiparire"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Reîmprospătează"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "Firmware MK3 detectat pe imprimanta MK3S"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "Firmware MK3S detectat pe imprimanta MK3"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2589,6 +2589,11 @@ msgstr "Printer pregătit"
 msgid "Set not Ready"
 msgstr "Print. nu pregătit"
 
+#. MSG_REPRINT c=10
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Retiparire"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."
 

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2579,7 +2579,7 @@ msgstr "Printer pregătit"
 msgid "Set not Ready"
 msgstr "Print. nu pregătit"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Retiparire"

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2573,7 +2573,7 @@ msgstr "Nie je pripravené"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Predtlač"
+msgstr "Vytlačiť znova"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyberte starý filament a stlačte tlačidlo pre zavedenie nového."

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 a staršie"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 a novšie"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "Očakávaná verzia %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Zrušiť"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Doladenie Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Všetko OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Všetko je hotové!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Vždy"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Okolie"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "Došli oba Z vozíky k hornému dorazu?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Automat."
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "Autozav. filamentu"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,52 +113,52 @@ msgid "Avoiding grind"
 msgstr "Avoiding grind"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Os"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Dĺžka osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Späť"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Podložka"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Zahrievanie podložky"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Podložka OK."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Korekcia podložky"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +166,54 @@ msgstr ""
 "Kalibrácia Z zlyhala. Senzor nezopol. Znečistená tryska? Čakám na reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Podložka/Zohrievanie"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Stav remeňa"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Test remeňa"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Nastal výpadok prúdu. Obnoviť tlač?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Jasné"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Podsvietenie"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "COMMUNICATION ERROR"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Kalibrácia XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Kalibrovať Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +222,13 @@ msgstr ""
 " tlačidlom."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Kalibrujem Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,156 +237,156 @@ msgstr ""
 "tlačidlom."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Kalibr. východziu p."
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Kalibrácia"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Kalibrácia OK"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Selektor alebo Idler nie je možné presunúť."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "Nie je možné vykonať akciu, filament je už zavedený. Najskôr ho vytiahnite."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "Karta vysunutá"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Zmeniť SD kartu"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Vymeniť filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Výmena úspešná!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Výmena ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Kontrola osi X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Kontrola osi Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Kontrola osi Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Kontrola podložky"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Kontrola endstopu"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Kontrolujem súbor"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Kontrola hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Kontrola senzorov"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Kontroly"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "Vymazanie chyby TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Nesprávna farba"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Komunitný prekl."
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Pokr."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Schladiť"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Kopírovať vybraný jazyk?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Náraz"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Det. nárazu"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Zistený náraz."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -398,34 +397,34 @@ msgstr ""
 "Normálnom režime"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Odstrihnúť fil."
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Strihanie"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Dátum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Tmavý"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Vypnúť"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Vypnúť motory"
 
@@ -437,8 +436,8 @@ msgid "Disengaging idler"
 msgstr "Uvoľnenie idlera"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -448,7 +447,7 @@ msgstr ""
 "manuálu, kapitola Začíname, odstavec Nastavenie prvej vrstvy."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -456,14 +455,14 @@ msgstr ""
 "Chcete opakovať posledný krok a pozmeniť vzdialenosť medzi tryskou a "
 "podložkou?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Hotov"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "Korekcia E"
 
@@ -492,13 +491,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Wait for User"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "ERROR:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Vysunúť z MMU"
 
@@ -510,17 +509,17 @@ msgid "Ejecting filament"
 msgstr "Vysunutie filamentu"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Koncový spínač"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Kon. spínač nezopol"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Konc. spínače"
 
@@ -532,45 +531,45 @@ msgid "Engaging idler"
 msgstr "Zapojenie idlera"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Extrúder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Extrúder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "F. autozav."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "F. zasek"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "F. výpadok"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "FIL. ALREADY LOADED"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA DIDNT TRIGGER"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -579,7 +578,7 @@ msgstr ""
 "že filament sa môže hýbať a FINDA funguje."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -588,65 +587,65 @@ msgstr ""
 "správne."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. STUCK"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "FS Akcia"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR DIDNT TRIGG."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR TOO EARLY"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. STUCK"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME ERROR"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Štatistiky zlyhaní"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "Zlyhania MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Falošné spustenie"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Rýchlosť vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Test ventilátora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Kontr. vent."
 
@@ -675,46 +674,46 @@ msgid "Feeding to nozzle"
 msgstr "Zavedenie do trysky"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Výpadky filam."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlačený a správnej farby?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Filament nezavedený"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -723,7 +722,7 @@ msgstr ""
 "filament môže hýbať a senzor funguje správne."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -732,7 +731,7 @@ msgstr ""
 "filament dosiahol fsenzor a senzor funguje správne."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -741,42 +740,42 @@ msgstr ""
 " či je PTFE trubička priechodzia a senzor funguje správne."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Spotrebovaný filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "Súbor nekompletný. Pokračovať?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Dokončovanie pohybu"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Kal. prvej vrstvy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Najskôr pomocou selftestu skontrolujem najčastejšie chyby vznikajúce pri "
 "zostavení tlačiarne."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Prietok"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -785,28 +784,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Predný tlačový vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Predná st.[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Predný/ľavý vent."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code pripravený pre inú úroveň. Pokračovať?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -814,14 +813,14 @@ msgstr ""
 "G-code pripravený pre inú verziu. Vygenerujte G-code znova. Tlač zrušená."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code je pripravený pre iný typ tlačiarne.Pokračovať?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -830,12 +829,12 @@ msgstr ""
 "zrušená."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code je pripravený pre novší firmware. Pokračovať?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -844,35 +843,35 @@ msgstr ""
 "zrušená."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "HW nastavenie"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Zohr./Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Zahrievanie"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Zohrievanie prerušené bezpečnostným časovačom."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Zahrievanie OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -882,7 +881,7 @@ msgstr ""
 "nastavenia, v ktorom skalibrujem os Z. Potom budete môcť začať tlačiť."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -891,8 +890,8 @@ msgstr ""
 "previedla kalibračným procesom?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Vys. výkon"
 
@@ -903,48 +902,48 @@ msgid "Homing"
 msgstr "Návrat"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend má 280C! Tryska je vymenená a utiahnutá podľa špecifikácie?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Hotend vent.:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Teraz urobím XYZ kalibráciu. Zaberie to až 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Teraz urobím kalibráciu Z."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "IDLER CANNOT HOME"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "IDLER CANNOT MOVE"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "KONTROLA FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "INVALID TOOL"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -953,307 +952,305 @@ msgstr ""
 "Platne"
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Zlepšenie bodu kalibrácie podložky"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Informácie"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Načítanie SD karty"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Vložte filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Vložte filament (nezavadzajte) do extrúderu a stlačte tlačidlo"
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Interná chyba. Skúste resetovať MMU alebo aktualizovať firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Je filament zavedený?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Je platňa na podložke?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Opakovanie"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Posledná tlač"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Zlyhanie posl. tlače"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Vľavo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Ľavý vent na tryske?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Lava str.[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Normálne"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Stlmené"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Korekcia lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Doladenie osi Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Zaviesť všetko"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Zaviesť filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Zaved. do trysky"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Záťažový test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Čistenie farby"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Zavedenie filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Uvoľnená remenica"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Hlasný"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW UPDATE NEEDED"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Chyba MMU Firmwaru, resetujte MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "MMU mod"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NOT RESPONDING"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU: Obnovenie teploty..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SAMOTEST ZLYHAL"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "Zlyhanie MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "MMU zlyhalo"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU neodpovedá správne.Skontrolujte zapojenie a konektory."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU neodpovedá. Skontrolujte zapojenie a konektory."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU pripojene"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Komp. magnetu"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Hlavná ponuka"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Merané skos."
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Meriam referenčnú výšku kalibračného bodu"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Mriežka"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Vyrovnanie podl."
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Režim"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Prebieha zmena modu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Viac podrobností online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Posunúť X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Posunúť Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Posunúť Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Posunúť os"
 
@@ -1264,96 +1261,95 @@ msgid "Moving selector"
 msgstr "Presun selektora"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Vyšla nová verzia firmware:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Nie"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Žiadna SD karta"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Bez pohybu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Žiadne"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normál"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Nezapojené"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Netočí sa"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Teraz skalibrujem vzdialenosť medzi koncom trysky a povrchom podložky."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Teraz predhrejem trysku pre PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Teraz odstráňte testovací výtlačok z platne."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Tryska"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Výmena trysky"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Tryska"
 
@@ -1364,80 +1360,80 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Vyp"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Neplatné hodnoty nastavenia. Bude použité predvolené PID, Esteps atď."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "Zap"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "Raz"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSED THERMAL ERROR"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "PID kal. ukončená"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "PID kalibrácia"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "Nahrievanie PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "Kalibrácia PINDA zlyhala"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1446,7 +1442,7 @@ msgstr ""
 "menu Nastavenia->PINDA kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "PULLEY CANNOT MOVE"
 
@@ -1457,13 +1453,13 @@ msgid "Parking selector"
 msgstr "Parkovanie selektora"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Pozastaviť tlač"
 
@@ -1474,7 +1470,7 @@ msgid "Performing cut"
 msgstr "Strihanie"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1483,7 +1479,7 @@ msgstr ""
 "tryska zachytí papier, ihneď vypnite tlačiareň."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1492,35 +1488,35 @@ msgstr ""
 "reštartovaním tlačiarne."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Prosím skontrolujte zapojenie IR senzoru a vyberte filament"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Skontrolujte:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Prosím očistite podložku a stlačte tlačidlo."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 "Pre úspešnú kalibráciu očistite prosím tlačovú trysku. Potvrďte tlačidlom."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Prosím vložte filament do extrúderu a stlačte tlačidlo k jeho zavedeniu"
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1529,104 +1525,104 @@ msgstr ""
 "zavedeniu"
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Prosím najskôr zaveďte filament"
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Prosím otvorte idler a manuálne odstráňte filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Umiestnite prosím platňu na podložku"
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Pre vysunutie filamentu stlačte tlačidlo"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Prosím vyberte urýchlene filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Najskôr prosím odstráňte prevozné pomôcky."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Odstráňte prosím platňu z podložky."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Najskôr spustite kalibráciu XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Prosím vyberte filament a zopakujte túto akciu"
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Aktualizujte prosím."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Čakajte prosím"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Výpadky prúdu"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Predohrev"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Predhrejte trysku!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Predohrev trysky. Prosím čakajte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Predohrev k strihu"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Predhrev k vysunutiu"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Predhrev k zavedeniu"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Predohrev k vybratiu"
 
@@ -1637,48 +1633,48 @@ msgid "Preparing blade"
 msgstr "Príprava čepele"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Stlačte tlačidlo"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pre zahriatie trysky a pokračovanie stlačte tlačidlo."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Tlač prerušená"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Tlačový vent.:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Tlač z SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Tlač pozastavená"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Čas tlače"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "IP adr. tlačiarne:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1687,12 +1683,12 @@ msgstr ""
 "kapitola Začíname, odstavec Postup kalibrácie."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Priemer trysky tlačiarne sa líši od G-code. Pokračovať?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1701,7 +1697,7 @@ msgstr ""
 "Tlač zrušená."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Motor remenice sa zasekol. Skontrolujte, že sa remenica môže hýbať a jej "
@@ -1714,32 +1710,32 @@ msgid "Pushing filament"
 msgstr "Tlačenie filamentu"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "QUEUE FULL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Zadná str.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Obnovovanie tlače"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Premenovať"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1748,24 +1744,24 @@ msgstr ""
 "nástroj mimo rozsah (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Pokračovať"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Obnovenie tlače"
 
@@ -1776,7 +1772,7 @@ msgid "Retract from FINDA"
 msgstr "Vybrať z FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Znova"
 
@@ -1787,17 +1783,17 @@ msgid "Returning selector"
 msgstr "Návrat selektora"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Vpravo"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Pravá str.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1806,64 +1802,64 @@ msgstr ""
 "kalibračný proces od začiatku. Pokračovať?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "SD karta"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELECTOR CANNOT HOME"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECTOR CANNOT MOVE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "ZASTAVENE."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Hľadám kalibračný bod podložky"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Vybrať"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Zvoľte filament pre kalibráciu prvej vrstvy z nasledujúceho menu"
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Zvoľte filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Výber jazyka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vyberte teplotu predohrevu trysky ktorá zodpovedá vášmu materiálu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Zvoľte teplotu, ktorá zodpovedá vášmu materiálu."
 
@@ -1874,72 +1870,72 @@ msgid "Selecting fil. slot"
 msgstr "Vyber slotu fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Samotest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Začiatok testu"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Samotest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Chyba samotestu!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Samotest zlyhal"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Bude spustený test pre kalibráciu presného návratu."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Senzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor overený, vyberte filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Nastavte teplotu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Nastavenia"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Ťažké skos."
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Platňa"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1952,23 +1948,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Stav konc. spin."
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Tichý"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Ľahké skos."
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1977,125 +1973,125 @@ msgstr ""
 "zoradenie je 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Vyskytol sa problém, zarovnám os Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Triediť"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Triedenie súborov"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Rýchlosť"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Točí sa"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Je vyžadovaná stabilná izbová teplota 21-26C a pevná podložka."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Štatistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Tichý"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Platne"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Zast."
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Zastaviť tlač"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Prísne"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Podpora"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Prehodené"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "THERMAL ANOMALY"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "TMC DRIVER ERROR"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "TMC DRIVER RESET"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRIVER SHORTED"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC OVERHEAT ERROR"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERVOLTAGE ERR"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2104,27 +2100,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Termálny model zatiaľ nebol kalibrovaný"
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Teplota"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Teploty"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Kontrola filamentu"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2132,7 +2128,7 @@ msgstr ""
 "pohyb."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2140,7 +2136,7 @@ msgstr ""
 "pohyb."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2150,7 +2146,7 @@ msgstr ""
 "výšku. Postupujte podľa obrázku v handbooku (kapitola Kalibrácia)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2159,63 +2155,63 @@ msgstr ""
 "Začíname, sekcia Postup kalibrácie."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Čas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Časovač"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Celkom"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Celkom zlyhaní"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Filament celkom"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Celkový čas tlače"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Ladiť"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "UNLOAD MANUALLY"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Výsuv"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Vybrať filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Vysúvanie filamentu"
 
@@ -2232,23 +2228,23 @@ msgid "Unloading to pulley"
 msgstr "Vysúv. do remenice"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Overenie zlyhalo, vyberte filament a skúste znova."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Napätie"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "WARNING TMC TOO HOT"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2261,191 +2257,197 @@ msgstr ""
 "Tichom režime"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Čaká sa na užívateľa"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Čaká sa na ochladenie PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Čakanie na schladenie trysky a podložky."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Varovať"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Varovanie: Došlo k zmene typu tlačiarne a matičnej dosky."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Varovanie: Došlo k zmene typu matičnej dosky."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Varovanie: Došlo k zmene typu tlačiarne."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Bolo vysunutie filamentu úspešné?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Chyba zapojenia"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Sprievodca"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "Korekcia X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "Detaily XYZ kal."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Kalibrácia XYZ v poriadku. Skosenie bude automaticky vyrovnané pri tlači."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibrácia XYZ v poriadku. X/Y osi mierne skosené. Dobrá práca!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibrácia XYZ je nepresná. Predné kalibračné body sú nedostupné."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibrácia XYZ je nepresná. Pravý predný bod je nedostupný."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibrácia XYZ zlyhala. Kalibračný bod podložky nenájdený."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Kalibrácia XYZ zlyhala. Predné kalibračné body sú nedostupné."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibrácia XYZ zlyhala. Nahliadnite do manuálu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Kalibrácia XYZ zlyhala. Pravý predný bod je nedostupný."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibrácia XYZ v poriadku. X/Y osi sú kolmé. Gratulujeme!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Y vzdialenosť od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Korekcia Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Áno"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Sprievodcu môžete kedykoľvek znovu spustiť z menu Kalibrácia -> Sprievodca"
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Korekcia Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Počet meraní Z"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] odsadenie bodu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "a stlačte tlačidlo"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "k zavedeniu filam."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "k vybraniu filamentu"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "neznámy"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "neznámy stav"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Obnoviť"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "MMU vyp. prúdu"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT VYSUNUTY"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2454,12 +2456,12 @@ msgstr ""
 " Skontrolujte snímače a kabeláž."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "ZLYHALO ZAVED. EXTR"
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2468,28 +2470,28 @@ msgstr ""
 " potreby upravte kalibráciu snímača."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU CHYBA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Výmena materiálu"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Odstráňte vysunutý filament z prednej časti MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2498,7 +2500,7 @@ msgstr ""
 " v selektore nie je žiadny filament a FINDA funguje správne."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2506,47 +2508,55 @@ msgstr ""
 "verziu 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Predzásobenie MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "MK3 firmware na MK3S tlačiarni"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "MK3S firmware na MK3 tlačiarni"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "NEZNÁMA CHYBA"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Vyskytla sa neočakávaná chyba."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Vysunúť"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "ZMENA FILAMENTU"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Zaviesť"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Výmena filamentu M600. Vložte nový filament alebo vysuňte starý."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Citlivosť"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Vyrovnanie platne zlyhalo. Spustite kalibráciu Z."
 
@@ -2563,16 +2573,7 @@ msgstr "Nie je pripravené"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Dotlac"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Obnoviť"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "MK3 firmware na MK3S tlačiarni"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "MK3S firmware na MK3 tlačiarni"
+msgstr "Predtlač"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyberte starý filament a stlačte tlačidlo pre zavedenie nového."

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 a staršie"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 a novšie"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "Očakávaná verzia %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Zrušiť"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Doladenie Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Všetko OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Všetko je hotové!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Vždy"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Okolie"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "Došli oba Z vozíky k hornému dorazu?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Automat."
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "Autozav. filamentu"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Avoiding grind"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Os"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Dĺžka osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Späť"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Podložka"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Zahrievanie podložky"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Podložka OK."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Korekcia podložky"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,54 +167,54 @@ msgstr ""
 "Kalibrácia Z zlyhala. Senzor nezopol. Znečistená tryska? Čakám na reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Podložka/Zohrievanie"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Stav remeňa"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Test remeňa"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Nastal výpadok prúdu. Obnoviť tlač?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Jasné"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Podsvietenie"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "COMMUNICATION ERROR"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Kalibrácia XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Kalibrovať Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +223,13 @@ msgstr ""
 " tlačidlom."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Kalibrujem Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,156 +238,156 @@ msgstr ""
 "tlačidlom."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Kalibr. východziu p."
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Kalibrácia"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Kalibrácia OK"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Selektor alebo Idler nie je možné presunúť."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "Nie je možné vykonať akciu, filament je už zavedený. Najskôr ho vytiahnite."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "Karta vysunutá"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Zmeniť SD kartu"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Vymeniť filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Výmena úspešná!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Výmena ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Kontrola osi X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Kontrola osi Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Kontrola osi Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Kontrola podložky"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Kontrola endstopu"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Kontrolujem súbor"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Kontrola hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Kontrola senzorov"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Kontroly"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "Vymazanie chyby TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Nesprávna farba"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Komunitný prekl."
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Pokr."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Schladiť"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Kopírovať vybraný jazyk?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Náraz"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Det. nárazu"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Zistený náraz."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -397,34 +398,34 @@ msgstr ""
 "Normálnom režime"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Odstrihnúť fil."
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Strihanie"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Dátum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Tmavý"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Vypnúť"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Vypnúť motory"
 
@@ -436,8 +437,8 @@ msgid "Disengaging idler"
 msgstr "Uvoľnenie idlera"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -447,7 +448,7 @@ msgstr ""
 "manuálu, kapitola Začíname, odstavec Nastavenie prvej vrstvy."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -455,14 +456,14 @@ msgstr ""
 "Chcete opakovať posledný krok a pozmeniť vzdialenosť medzi tryskou a "
 "podložkou?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Hotov"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "Korekcia E"
 
@@ -491,13 +492,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Wait for User"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "ERROR:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Vysunúť z MMU"
 
@@ -509,17 +510,17 @@ msgid "Ejecting filament"
 msgstr "Vysunutie filamentu"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Koncový spínač"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Kon. spínač nezopol"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Konc. spínače"
 
@@ -531,45 +532,45 @@ msgid "Engaging idler"
 msgstr "Zapojenie idlera"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Extrúder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Extrúder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "F. autozav."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "F. zasek"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "F. výpadok"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "FIL. ALREADY LOADED"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA DIDNT TRIGGER"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -578,7 +579,7 @@ msgstr ""
 "že filament sa môže hýbať a FINDA funguje."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -587,65 +588,65 @@ msgstr ""
 "správne."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. STUCK"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "FS Akcia"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR DIDNT TRIGG."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR TOO EARLY"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. STUCK"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME ERROR"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Štatistiky zlyhaní"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "Zlyhania MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Falošné spustenie"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Rýchlosť vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Test ventilátora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Kontr. vent."
 
@@ -674,46 +675,46 @@ msgid "Feeding to nozzle"
 msgstr "Zavedenie do trysky"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Výpadky filam."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlačený a správnej farby?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Filament nezavedený"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -722,7 +723,7 @@ msgstr ""
 "filament môže hýbať a senzor funguje správne."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -731,7 +732,7 @@ msgstr ""
 "filament dosiahol fsenzor a senzor funguje správne."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -740,42 +741,42 @@ msgstr ""
 " či je PTFE trubička priechodzia a senzor funguje správne."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Spotrebovaný filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "Súbor nekompletný. Pokračovať?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Dokončovanie pohybu"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Kal. prvej vrstvy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Najskôr pomocou selftestu skontrolujem najčastejšie chyby vznikajúce pri "
 "zostavení tlačiarne."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Prietok"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -784,28 +785,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Predný tlačový vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Predná st.[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Predný/ľavý vent."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code pripravený pre inú úroveň. Pokračovať?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -813,14 +814,14 @@ msgstr ""
 "G-code pripravený pre inú verziu. Vygenerujte G-code znova. Tlač zrušená."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code je pripravený pre iný typ tlačiarne.Pokračovať?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -829,12 +830,12 @@ msgstr ""
 "zrušená."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code je pripravený pre novší firmware. Pokračovať?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -843,35 +844,35 @@ msgstr ""
 "zrušená."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "HW nastavenie"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Zohr./Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Zahrievanie"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Zohrievanie prerušené bezpečnostným časovačom."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Zahrievanie OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -881,7 +882,7 @@ msgstr ""
 "nastavenia, v ktorom skalibrujem os Z. Potom budete môcť začať tlačiť."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -890,8 +891,8 @@ msgstr ""
 "previedla kalibračným procesom?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Vys. výkon"
 
@@ -902,48 +903,48 @@ msgid "Homing"
 msgstr "Návrat"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend má 280C! Tryska je vymenená a utiahnutá podľa špecifikácie?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Hotend vent.:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Teraz urobím XYZ kalibráciu. Zaberie to až 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Teraz urobím kalibráciu Z."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "IDLER CANNOT HOME"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "IDLER CANNOT MOVE"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "KONTROLA FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "INVALID TOOL"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -952,305 +953,307 @@ msgstr ""
 "Platne"
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Zlepšenie bodu kalibrácie podložky"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Informácie"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Načítanie SD karty"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Vložte filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Vložte filament (nezavadzajte) do extrúderu a stlačte tlačidlo"
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Interná chyba. Skúste resetovať MMU alebo aktualizovať firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Je filament zavedený?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Je platňa na podložke?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Opakovanie"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Posledná tlač"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Zlyhanie posl. tlače"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Vľavo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Ľavý vent na tryske?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Lava str.[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Normálne"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Stlmené"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Korekcia lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Doladenie osi Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Zaviesť všetko"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Zaviesť filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Zaved. do trysky"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Záťažový test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Čistenie farby"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Zavedenie filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Uvoľnená remenica"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Hlasný"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW UPDATE NEEDED"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Chyba MMU Firmwaru, resetujte MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "MMU mod"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU NOT RESPONDING"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU: Obnovenie teploty..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SAMOTEST ZLYHAL"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "Zlyhanie MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "MMU zlyhalo"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU neodpovedá správne.Skontrolujte zapojenie a konektory."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU neodpovedá. Skontrolujte zapojenie a konektory."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU pripojene"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Komp. magnetu"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Hlavná ponuka"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Merané skos."
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Meriam referenčnú výšku kalibračného bodu"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Mriežka"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Vyrovnanie podl."
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Režim"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Prebieha zmena modu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Model"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Viac podrobností online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Posunúť X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Posunúť Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Posunúť Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Posunúť os"
 
@@ -1261,95 +1264,96 @@ msgid "Moving selector"
 msgstr "Presun selektora"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Vyšla nová verzia firmware:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Nie"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Žiadna SD karta"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Bez pohybu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Žiadne"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normál"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Nezapojené"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Netočí sa"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Teraz skalibrujem vzdialenosť medzi koncom trysky a povrchom podložky."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Teraz predhrejem trysku pre PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Teraz odstráňte testovací výtlačok z platne."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Tryska"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Výmena trysky"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Tryska"
 
@@ -1360,80 +1364,80 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Vyp"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Neplatné hodnoty nastavenia. Bude použité predvolené PID, Esteps atď."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "Zap"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "Raz"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSED THERMAL ERROR"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "PID kal. ukončená"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "PID kalibrácia"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "Nahrievanie PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "Kalibrácia PINDA zlyhala"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1442,7 +1446,7 @@ msgstr ""
 "menu Nastavenia->PINDA kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "PULLEY CANNOT MOVE"
 
@@ -1453,13 +1457,13 @@ msgid "Parking selector"
 msgstr "Parkovanie selektora"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Pozastaviť tlač"
 
@@ -1470,7 +1474,7 @@ msgid "Performing cut"
 msgstr "Strihanie"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1479,7 +1483,7 @@ msgstr ""
 "tryska zachytí papier, ihneď vypnite tlačiareň."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1488,35 +1492,35 @@ msgstr ""
 "reštartovaním tlačiarne."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Prosím skontrolujte zapojenie IR senzoru a vyberte filament"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Skontrolujte:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Prosím očistite podložku a stlačte tlačidlo."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 "Pre úspešnú kalibráciu očistite prosím tlačovú trysku. Potvrďte tlačidlom."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Prosím vložte filament do extrúderu a stlačte tlačidlo k jeho zavedeniu"
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1525,104 +1529,104 @@ msgstr ""
 "zavedeniu"
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Prosím najskôr zaveďte filament"
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Prosím otvorte idler a manuálne odstráňte filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Umiestnite prosím platňu na podložku"
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Pre vysunutie filamentu stlačte tlačidlo"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Prosím vyberte urýchlene filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Najskôr prosím odstráňte prevozné pomôcky."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Odstráňte prosím platňu z podložky."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Najskôr spustite kalibráciu XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Prosím vyberte filament a zopakujte túto akciu"
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Aktualizujte prosím."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Čakajte prosím"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Výpadky prúdu"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Predohrev"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Predhrejte trysku!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Predohrev trysky. Prosím čakajte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Predohrev k strihu"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Predhrev k vysunutiu"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Predhrev k zavedeniu"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Predohrev k vybratiu"
 
@@ -1633,48 +1637,48 @@ msgid "Preparing blade"
 msgstr "Príprava čepele"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Stlačte tlačidlo"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pre zahriatie trysky a pokračovanie stlačte tlačidlo."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Tlač prerušená"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Tlačový vent.:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Tlač z SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Tlač pozastavená"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Čas tlače"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "IP adr. tlačiarne:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1683,12 +1687,12 @@ msgstr ""
 "kapitola Začíname, odstavec Postup kalibrácie."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Priemer trysky tlačiarne sa líši od G-code. Pokračovať?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1697,7 +1701,7 @@ msgstr ""
 "Tlač zrušená."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Motor remenice sa zasekol. Skontrolujte, že sa remenica môže hýbať a jej "
@@ -1710,32 +1714,32 @@ msgid "Pushing filament"
 msgstr "Tlačenie filamentu"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "QUEUE FULL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Zadná str.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Obnovovanie tlače"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Premenovať"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1744,24 +1748,24 @@ msgstr ""
 "nástroj mimo rozsah (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Pokračovať"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Obnovenie tlače"
 
@@ -1772,7 +1776,7 @@ msgid "Retract from FINDA"
 msgstr "Vybrať z FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Znova"
 
@@ -1783,17 +1787,17 @@ msgid "Returning selector"
 msgstr "Návrat selektora"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Vpravo"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Pravá str.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1802,64 +1806,64 @@ msgstr ""
 "kalibračný proces od začiatku. Pokračovať?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "SD karta"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "SELECTOR CANNOT HOME"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECTOR CANNOT MOVE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "ZASTAVENE."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Hľadám kalibračný bod podložky"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Vybrať"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Zvoľte filament pre kalibráciu prvej vrstvy z nasledujúceho menu"
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Zvoľte filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Výber jazyka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vyberte teplotu predohrevu trysky ktorá zodpovedá vášmu materiálu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Zvoľte teplotu, ktorá zodpovedá vášmu materiálu."
 
@@ -1870,72 +1874,72 @@ msgid "Selecting fil. slot"
 msgstr "Vyber slotu fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Samotest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Začiatok testu"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Samotest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Chyba samotestu!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Samotest zlyhal"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Bude spustený test pre kalibráciu presného návratu."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Senzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor overený, vyberte filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Nastavte teplotu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Nastavenia"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Ťažké skos."
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Platňa"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1948,23 +1952,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Stav konc. spin."
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Tichý"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Ľahké skos."
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1973,125 +1977,125 @@ msgstr ""
 "zoradenie je 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Vyskytol sa problém, zarovnám os Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Triediť"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Triedenie súborov"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Rýchlosť"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Točí sa"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Je vyžadovaná stabilná izbová teplota 21-26C a pevná podložka."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Štatistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Tichý"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Platne"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Zast."
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Zastaviť tlač"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Prísne"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Podpora"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Prehodené"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "THERMAL ANOMALY"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "TMC DRIVER ERROR"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "TMC DRIVER RESET"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRIVER SHORTED"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC OVERHEAT ERROR"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERVOLTAGE ERR"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2100,27 +2104,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Termálny model zatiaľ nebol kalibrovaný"
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Teplota"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Teploty"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Kontrola filamentu"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2128,7 +2132,7 @@ msgstr ""
 "pohyb."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2136,7 +2140,7 @@ msgstr ""
 "pohyb."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2146,7 +2150,7 @@ msgstr ""
 "výšku. Postupujte podľa obrázku v handbooku (kapitola Kalibrácia)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2155,63 +2159,63 @@ msgstr ""
 "Začíname, sekcia Postup kalibrácie."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Čas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Časovač"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Celkom"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Celkom zlyhaní"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Filament celkom"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Celkový čas tlače"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Ladiť"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "UNLOAD MANUALLY"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Výsuv"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Vybrať filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Vysúvanie filamentu"
 
@@ -2228,23 +2232,23 @@ msgid "Unloading to pulley"
 msgstr "Vysúv. do remenice"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Overenie zlyhalo, vyberte filament a skúste znova."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Napätie"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "WARNING TMC TOO HOT"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2257,197 +2261,191 @@ msgstr ""
 "Tichom režime"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Čaká sa na užívateľa"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Čaká sa na ochladenie PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Čakanie na schladenie trysky a podložky."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Varovať"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Varovanie: Došlo k zmene typu tlačiarne a matičnej dosky."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Varovanie: Došlo k zmene typu matičnej dosky."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Varovanie: Došlo k zmene typu tlačiarne."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Bolo vysunutie filamentu úspešné?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Chyba zapojenia"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Sprievodca"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "Korekcia X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "Detaily XYZ kal."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Kalibrácia XYZ v poriadku. Skosenie bude automaticky vyrovnané pri tlači."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibrácia XYZ v poriadku. X/Y osi mierne skosené. Dobrá práca!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibrácia XYZ je nepresná. Predné kalibračné body sú nedostupné."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibrácia XYZ je nepresná. Pravý predný bod je nedostupný."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibrácia XYZ zlyhala. Kalibračný bod podložky nenájdený."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Kalibrácia XYZ zlyhala. Predné kalibračné body sú nedostupné."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibrácia XYZ zlyhala. Nahliadnite do manuálu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Kalibrácia XYZ zlyhala. Pravý predný bod je nedostupný."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibrácia XYZ v poriadku. X/Y osi sú kolmé. Gratulujeme!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Y vzdialenosť od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Korekcia Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Áno"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Sprievodcu môžete kedykoľvek znovu spustiť z menu Kalibrácia -> Sprievodca"
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Korekcia Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Počet meraní Z"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] odsadenie bodu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "a stlačte tlačidlo"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "k zavedeniu filam."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "k vybraniu filamentu"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "neznámy"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "neznámy stav"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Obnoviť"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "MMU vyp. prúdu"
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT VYSUNUTY"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2456,12 +2454,12 @@ msgstr ""
 " Skontrolujte snímače a kabeláž."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "ZLYHALO ZAVED. EXTR"
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2470,28 +2468,28 @@ msgstr ""
 " potreby upravte kalibráciu snímača."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU CHYBA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Výmena materiálu"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Odstráňte vysunutý filament z prednej časti MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2500,7 +2498,7 @@ msgstr ""
 " v selektore nie je žiadny filament a FINDA funguje správne."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2508,55 +2506,47 @@ msgstr ""
 "verziu 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Predzásobenie MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "MK3 firmware na MK3S tlačiarni"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "MK3S firmware na MK3 tlačiarni"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "NEZNÁMA CHYBA"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Vyskytla sa neočakávaná chyba."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Vysunúť"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "ZMENA FILAMENTU"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Zaviesť"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Výmena filamentu M600. Vložte nový filament alebo vysuňte starý."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Citlivosť"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Vyrovnanie platne zlyhalo. Spustite kalibráciu Z."
 
@@ -2571,9 +2561,18 @@ msgid "Set not Ready"
 msgstr "Nie je pripravené"
 
 #. MSG_REPRINT c=7
-#: ../../Firmware/ultralcd.cpp:5189
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Dotlac"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Obnoviť"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "MK3 firmware na MK3S tlačiarni"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "MK3S firmware na MK3 tlačiarni"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyberte starý filament a stlačte tlačidlo pre zavedenie nového."

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2570,6 +2570,11 @@ msgstr "Pripravené"
 msgid "Set not Ready"
 msgstr "Nie je pripravené"
 
+#. MSG_REPRINT c=6
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Dotlac"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyberte starý filament a stlačte tlačidlo pre zavedenie nového."
 

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2570,7 +2570,7 @@ msgstr "Pripravené"
 msgid "Set not Ready"
 msgstr "Nie je pripravené"
 
-#. MSG_REPRINT c=6
+#. MSG_REPRINT c=7
 #: ../../Firmware/ultralcd.cpp:5189
 msgid "Reprint"
 msgstr "Dotlac"

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2560,7 +2560,7 @@ msgstr "Pripravené"
 msgid "Set not Ready"
 msgstr "Nie je pripravené"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Dotlac"

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -17,90 +17,91 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
 msgid " 0.3 or older"
 msgstr " 0.3 el äldre"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
 msgid " 0.4 or newer"
 msgstr " 0.4 el nyare"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6660
+#: ../../Firmware/ultralcd.cpp:6677
 msgid "%s level expected"
 msgstr "%s nivå förväntad"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
-#: ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
+#: ../../Firmware/ultralcd.cpp:3599
 msgid ">Cancel"
 msgstr ">Avbryt"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2611
+#: ../../Firmware/ultralcd.cpp:2607
 msgid "Adjusting Z"
 msgstr "Justerar Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6868
+#: ../../Firmware/ultralcd.cpp:6887
 msgid "All correct"
 msgstr "Allt korrekt"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
 msgid "All is done. Happy printing!"
 msgstr "Allt är klart. God utskrift!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
 msgid "Always"
 msgstr "Alltid"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1367
+#: ../../Firmware/ultralcd.cpp:1365
 msgid "Ambient"
 msgstr "Omgivande"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2826
+#: ../../Firmware/ultralcd.cpp:2822
 msgid "Are left and right Z-carriages all up?"
 msgstr "Är båda Z-vagnarna helt uppe?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
 msgid "Assist"
 msgstr "Assist"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/ultralcd.cpp:5463
 msgid "Auto home"
 msgstr "Auto hem"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
 msgid "Auto power"
 msgstr "Auto kraft"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5292
+#: ../../Firmware/ultralcd.cpp:5297
 msgid "AutoLoad filament"
 msgstr "Autoladda filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2249
+#: ../../Firmware/ultralcd.cpp:2245
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,52 +114,52 @@ msgid "Avoiding grind"
 msgstr "Undviker slipning"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6639
+#: ../../Firmware/ultralcd.cpp:6656
 msgid "Axis"
 msgstr "Axel"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "Axis length"
 msgstr "Axellängd"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
-#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
-#: ../../Firmware/ultralcd.cpp:7382
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
+#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
+#: ../../Firmware/ultralcd.cpp:7402
 msgid "Back"
 msgstr "Tillbaka"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
-#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
+#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
+#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
 msgid "Bed"
 msgstr "Bädd"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
-#: ../../Firmware/ultralcd.cpp:528
+#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
+#: ../../Firmware/ultralcd.cpp:527
 msgid "Bed Heating"
 msgstr "Bädden värms upp"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
-#: ../../Firmware/ultralcd.cpp:531
+#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
+#: ../../Firmware/ultralcd.cpp:530
 msgid "Bed done"
 msgstr "Bädd klar"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/ultralcd.cpp:4572
 msgid "Bed level correct"
 msgstr "Bäddnivå korrekt"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
-#: ../../Firmware/Marlin_main.cpp:2984
-#: ../../Firmware/mesh_bed_calibration.cpp:2864
-#: ../../Firmware/mesh_bed_calibration.cpp:2872
-#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
+#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
+#: ../../Firmware/Marlin_main.cpp:2943
+#: ../../Firmware/mesh_bed_calibration.cpp:2880
+#: ../../Firmware/mesh_bed_calibration.cpp:2888
+#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,54 +168,54 @@ msgstr ""
 " på återställning."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6596
+#: ../../Firmware/ultralcd.cpp:6613
 msgid "Bed/Heater"
 msgstr "Bädd/Värmare"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Belt status"
 msgstr "Bält status"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4562
 msgid "Belt test"
 msgstr "Bält test"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
+#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
 msgid "Blackout occurred. Recover print?"
 msgstr "Blackout inträffat. Återställa utskr?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
 msgid "Bright"
 msgstr "Ljus"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
-#: ../../Firmware/ultralcd.cpp:5464
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
+#: ../../Firmware/ultralcd.cpp:5480
 msgid "Brightness"
 msgstr "Ljusstyrka"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "COMMUNICATION ERROR"
 msgstr "KOMMUNIKATIONSFEL"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/ultralcd.cpp:4566
 msgid "Calibrate XYZ"
 msgstr "Kalibrera XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
 msgid "Calibrate Z"
 msgstr "Kalibrera Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2791
+#: ../../Firmware/ultralcd.cpp:2787
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +224,13 @@ msgstr ""
 "Klicka när du är klar."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
-#: ../../Firmware/ultralcd.cpp:576
+#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
+#: ../../Firmware/ultralcd.cpp:575
 msgid "Calibrating Z"
 msgstr "Kalibrerar Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2790
+#: ../../Firmware/ultralcd.cpp:2786
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,156 +239,156 @@ msgstr ""
 "Klicka när du är klar."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6870
+#: ../../Firmware/ultralcd.cpp:6889
 msgid "Calibrating home"
 msgstr "Kalibrerar hem"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
 msgid "Calibration"
 msgstr "Kalibrering"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:587
+#: ../../Firmware/ultralcd.cpp:586
 msgid "Calibration done"
 msgstr "Kalibraring utförd"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
-#: ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:309
 msgid "Can't move Selector or Idler."
 msgstr "Kan inte flytta väljaren eller Idlern."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "Kan inte utföra åtgärden, filament är redan laddat. Ta bort det först."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7280
+#: ../../Firmware/ultralcd.cpp:7299
 msgid "Card removed"
 msgstr "Kort borttaget"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5252
+#: ../../Firmware/ultralcd.cpp:5258
 msgid "Change SD card"
 msgstr "Byt ut SD-kort"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
-#: ../../Firmware/ultralcd.cpp:5446
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
+#: ../../Firmware/ultralcd.cpp:5460
 msgid "Change filament"
 msgstr "Ändra filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2132
+#: ../../Firmware/ultralcd.cpp:2128
 msgid "Change success!"
 msgstr "Ändring utförd!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2179
+#: ../../Firmware/ultralcd.cpp:2175
 msgid "Changed correctly?"
 msgstr "Ändring korrekt?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
-#: ../../Firmware/ultralcd.cpp:6860
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Checking X axis"
 msgstr "Kontroll X-axel"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
-#: ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/ultralcd.cpp:6880
 msgid "Checking Y axis"
 msgstr "Kontroll Y-axel"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6862
+#: ../../Firmware/ultralcd.cpp:6881
 msgid "Checking Z axis"
 msgstr "Kontroll Z-axel"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
 msgid "Checking bed"
 msgstr "Kontroll bädd"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6859
+#: ../../Firmware/ultralcd.cpp:6878
 msgid "Checking endstops"
 msgstr "Kontroll ändlägen"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6955
+#: ../../Firmware/ultralcd.cpp:6974
 msgid "Checking file"
 msgstr "Kontrollerar fil"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6865
+#: ../../Firmware/ultralcd.cpp:6884
 msgid "Checking hotend"
 msgstr "Kontroll hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
-#: ../../Firmware/ultralcd.cpp:6867
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/ultralcd.cpp:6886
 msgid "Checking sensors"
 msgstr "Kontroll sensorer"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4418
+#: ../../Firmware/ultralcd.cpp:4407
 msgid "Checks"
 msgstr "Kontroller"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
 msgid "Clear TM error"
 msgstr "Rensa TM-fel"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2182
+#: ../../Firmware/ultralcd.cpp:2178
 msgid "Color not correct"
 msgstr "Färg ej korrekt"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
 msgid "Community made"
 msgstr "Allmänhetsgjord"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
 msgid "Cont."
 msgstr "Frts."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
 msgid "Cooldown"
 msgstr "Kyla ner"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3447
+#: ../../Firmware/ultralcd.cpp:3436
 msgid "Copy selected language?"
 msgstr "Kopiera det valda språket?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
-#: ../../Firmware/ultralcd.cpp:1237
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Crash"
 msgstr "Krock"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
-#: ../../Firmware/ultralcd.cpp:4140
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
+#: ../../Firmware/ultralcd.cpp:4129
 msgid "Crash det."
 msgstr "Krockdetekt."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
 msgid "Crash detected."
 msgstr "Krock upptäckt."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3363
+#: ../../Firmware/ultralcd.cpp:3352
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -398,34 +399,34 @@ msgstr ""
 "normalt läge"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
+#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
 msgid "Cut filament"
 msgstr "Skär filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
 msgid "Cutter"
 msgstr "Skärare"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1621
+#: ../../Firmware/ultralcd.cpp:1617
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
 msgid "Dim"
 msgstr "Dim"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
 msgid "Disable"
 msgstr "Inaktiv."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4454
+#: ../../Firmware/ultralcd.cpp:4443
 msgid "Disable steppers"
 msgstr "Inaktivera stepper"
 
@@ -437,8 +438,8 @@ msgid "Disengaging idler"
 msgstr "Kopplar ur Idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
-#: ../../Firmware/messages.cpp:11
+#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
+#: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -448,7 +449,7 @@ msgstr ""
 "Vänligen följ manualen Första lagrets kalibrering."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3920
+#: ../../Firmware/ultralcd.cpp:3909
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -456,14 +457,14 @@ msgstr ""
 "Vill du upprepa sista steget för justera avståndet mellan munstycket och "
 "bädden?"
 
-#. MSG_BTN_DONE c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
-#: ../../Firmware/mmu2_reporting.cpp:424
+#. MSG_DONE c=8
+#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:442
 msgid "Done"
 msgstr "Klar"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/ultralcd.cpp:3976
 msgid "E-correct"
 msgstr "E-korrektion"
 
@@ -492,13 +493,13 @@ msgid "ERR Wait for User"
 msgstr "FEL Inväntar anv"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
 msgid "ERROR:"
 msgstr "FEL:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
-#: ../../Firmware/ultralcd.cpp:5283
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
+#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
 msgid "Eject from MMU"
 msgstr "Utmat från MMU"
 
@@ -510,17 +511,17 @@ msgid "Ejecting filament"
 msgstr "Matar ut filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6626
 msgid "Endstop"
 msgstr "Ändläge"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6631
 msgid "Endstop not hit"
 msgstr "Ändlage inte nått"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6600
+#: ../../Firmware/ultralcd.cpp:6617
 msgid "Endstops"
 msgstr "Ändlägen"
 
@@ -532,45 +533,45 @@ msgid "Engaging idler"
 msgstr "Koppla in Idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/ultralcd.cpp:1672
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
+#: ../../Firmware/ultralcd.cpp:4037
 msgid "F. autoload"
 msgstr "F. autoladdn"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:4039
 msgid "F. jam detect"
 msgstr "F.stopp skett"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4036
 msgid "F. runout"
 msgstr "F. slut"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "FIL. ALREADY LOADED"
 msgstr "F. REDAN INLADDAT"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA TRIGGADES EJ"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -579,7 +580,7 @@ msgstr ""
 "manuellt. Se till att filamentet kan röra sig och att FINDA fungerar."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -588,65 +589,65 @@ msgstr ""
 "röra sig och att FINDA fungerar."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. STOPP"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
-#: ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "FS Action"
 msgstr "FS aktion"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR TRIGGADE EJ."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR FÖR TIDIG"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. STOPP"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME FEL"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5310
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Fail stats"
 msgstr "Felstatistik"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/ultralcd.cpp:5318
 msgid "Fail stats MMU"
 msgstr "Felstatistik MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6672
 msgid "False triggering"
 msgstr "Felaktig triggning"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
 msgid "Fan speed"
 msgstr "Fläktfart"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
-#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
-#: ../../Firmware/ultralcd.cpp:6858
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/ultralcd.cpp:6877
 msgid "Fan test"
 msgstr "Fläkttest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
 msgid "Fans check"
 msgstr "Fläktcheck"
 
@@ -675,46 +676,46 @@ msgid "Feeding to nozzle"
 msgstr "Matar till munstycke"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
-#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
-#: ../../Firmware/ultralcd.cpp:1292
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Fil. runouts"
 msgstr "Fil. avbrott"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:5466
 msgid "Fil. sensor"
 msgstr "Fil. sensor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
-#: ../../Firmware/ultralcd.cpp:2242
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
+#: ../../Firmware/ultralcd.cpp:2238
 msgid "Filament extruding & with correct color?"
 msgstr "Extruderas filament med rätt färg?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2181
+#: ../../Firmware/ultralcd.cpp:2177
 msgid "Filament not loaded"
 msgstr "Filament ej laddat"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
-#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
-#: ../../Firmware/ultralcd.cpp:6885
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
+#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
+#: ../../Firmware/ultralcd.cpp:6904
 msgid "Filament sensor"
 msgstr "Filament sensor"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -723,7 +724,7 @@ msgstr ""
 "filamentet kan röra sig och att sensorn fungerar."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -732,7 +733,7 @@ msgstr ""
 "filamentet kan röra sig och att sensorn fungerar."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -741,42 +742,42 @@ msgstr ""
 "extruder.Kontrollera PFFE-slang och att sensorn läser korrekt."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2323
+#: ../../Firmware/ultralcd.cpp:2319
 msgid "Filament used"
 msgstr "Använt filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7033
 msgid "File incomplete. Continue anyway?"
 msgstr "Filen är ofullständig. Fortsätta ändå?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41
+#: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
 msgid "Finishing movements"
 msgstr "Avslutar flyttning"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
+#: ../../Firmware/ultralcd.cpp:5120
 msgid "First layer cal."
 msgstr "Förstalager kalib."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3832
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Först kommer jag att utföra självtestet för att kontrollera de vanligaste "
 "monteringsproblemen."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5440
+#: ../../Firmware/ultralcd.cpp:5454
 msgid "Flow"
 msgstr "Flöde"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
+#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -785,28 +786,28 @@ msgstr ""
 " prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Front print fan?"
 msgstr "Frontfläkt?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2687
+#: ../../Firmware/ultralcd.cpp:2683
 msgid "Front side[µm]"
 msgstr "Frontsida[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6644
+#: ../../Firmware/ultralcd.cpp:6661
 msgid "Front/left fans"
 msgstr "Front/vänster fläkt"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
+#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code genererad för en annan nivå. Fortsätta?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
+#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -815,14 +816,14 @@ msgstr ""
 "Utskriften avbröts."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
-#: ../../Firmware/util.cpp:425
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
+#: ../../Firmware/util.cpp:421
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code genererad för en annan skrivartyp. Fortsätta?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
-#: ../../Firmware/util.cpp:426
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
+#: ../../Firmware/util.cpp:422
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -831,12 +832,12 @@ msgstr ""
 "igen. Utskriften avbröts."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code genererad för en nyare firmware. Fortsätta?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -845,35 +846,35 @@ msgstr ""
 "Utskriften avbröts."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
-#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
 msgid "HW Setup"
 msgstr "HW inställning"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6592
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Heater/Thermistor"
 msgstr "Värmare/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
-#: ../../Firmware/ultralcd.cpp:520
+#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
+#: ../../Firmware/ultralcd.cpp:519
 msgid "Heating"
 msgstr "Uppvärmning"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9407
+#: ../../Firmware/Marlin_main.cpp:9317
 msgid "Heating disabled by safety timer."
 msgstr "Uppvärmning avaktiverad av säkerhetstimer."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
-#: ../../Firmware/ultralcd.cpp:523
+#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
+#: ../../Firmware/ultralcd.cpp:522
 msgid "Heating done."
 msgstr "Uppvärmning klar."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -884,7 +885,7 @@ msgstr ""
 "att skriva ut."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -893,8 +894,8 @@ msgstr ""
 "installationsprocessen?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4155
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
+#: ../../Firmware/ultralcd.cpp:4144
 msgid "High power"
 msgstr "Hög kraft"
 
@@ -905,48 +906,48 @@ msgid "Homing"
 msgstr "Flyttar till hempos"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
+#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend temperatur är 280C! Är munstycket bytt och spänt enligt specs?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6876
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6895
 msgid "Hotend fan:"
 msgstr "Hotend-fläkt:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3837
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Jag kommer att utföra en xyz-kalibrering nu. Det tar upp till 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3859
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run z calibration now."
 msgstr "Jag kommer att utföra z-kalibrering nu."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT HOME"
 msgstr "IDLER HEMPOS FEL"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
 msgid "IDLER CANNOT MOVE"
 msgstr "IDLER KAN EJ FLYTTA"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "INSPECT FINDA"
 msgstr "KONTROLLERA FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "INVALID TOOL"
 msgstr "OGILTIGT VERKTYG"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3928
+#: ../../Firmware/ultralcd.cpp:3917
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -955,27 +956,27 @@ msgstr ""
 "Inställningar - HW inställning - Metallskiva."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2536
+#: ../../Firmware/mesh_bed_calibration.cpp:2546
 msgid "Improving bed calibration point"
 msgstr "Förbättrar bäddens kalibreringspunkt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
 msgid "Info screen"
 msgstr "Infoskärm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5265
 msgid "Init. SD card"
 msgstr "Init. SD-kort"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2118
+#: ../../Firmware/ultralcd.cpp:2114
 msgid "Insert filament"
 msgstr "Sätt i filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5885
+#: ../../Firmware/ultralcd.cpp:5902
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -984,278 +985,280 @@ msgstr ""
 "knappen."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Internt körtidsfel. Prova återställa MMU eller uppdatera firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
-#: ../../Firmware/ultralcd.cpp:3887
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
+#: ../../Firmware/ultralcd.cpp:3876
 msgid "Is filament loaded?"
 msgstr "Är filament laddat?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
+#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
 msgid "Is steel sheet on heatbed?"
 msgstr "Ligger metallskiva på värmebädden?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
+#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteration"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1260
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
+#: ../../Firmware/ultralcd.cpp:1258
 msgid "Last print"
 msgstr "Senaste utskrift"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
+#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
 msgid "Last print failures"
 msgstr "Senaste utskriftsfel"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2454
+#: ../../Firmware/ultralcd.cpp:2450
 msgid "Left"
 msgstr "Vänster"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
-#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
+#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
 msgid "Left hotend fan?"
 msgstr "Vänst hotend fläkt?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:2681
 msgid "Left side [µm]"
 msgstr "Vänstsida [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
 msgid "Level Bright"
 msgstr "Ljusnivå"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
 msgid "Level Dimmed"
 msgstr "Nivå dämpad"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/ultralcd.cpp:4474
 msgid "Lin. correction"
 msgstr "Linjär korrektion"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
-#: ../../Firmware/ultralcd.cpp:5203
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
+#: ../../Firmware/ultralcd.cpp:5201
 msgid "Live adjust Z"
 msgstr "Live justera Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
-#: ../../Firmware/ultralcd.cpp:4876
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
+#: ../../Firmware/ultralcd.cpp:4863
 msgid "Load All"
 msgstr "Ladda alla"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
-#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
+#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
+#: ../../Firmware/ultralcd.cpp:5302
 msgid "Load filament"
 msgstr "Ladda filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5281
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Load to nozzle"
 msgstr "Ladd till munstyck"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
 msgid "Loading Test"
 msgstr "Laddningstest"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2150
 msgid "Loading color"
 msgstr "Laddar färg"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
+#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
+#: ../../Firmware/ultralcd.cpp:3701
 msgid "Loading filament"
 msgstr "Laddar filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6632
+#: ../../Firmware/ultralcd.cpp:6649
 msgid "Loose pulley"
 msgstr "Lös pulley"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4183
 msgid "Loud"
 msgstr "Högt"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW UPDATE KRÄVS"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware internt fel, vänligen återställ MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
 msgid "MMU Mode"
 msgstr "MMU-läge"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "MMU NOT RESPONDING"
 msgstr "MMU SVARAR INTE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:364
+#: ../../Firmware/mmu2_reporting.cpp:382
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU försök igen: Återställer temperatur..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
-#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
+#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
+#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SJÄLVTEST FELADE"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
+#: ../../Firmware/ultralcd.cpp:1150
 msgid "MMU fails"
 msgstr "MMU felar"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1153
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1151
 msgid "MMU load fails"
 msgstr "MMU-laddn felar"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU svarar inte korrekt. Kontrollera kablarna och kontakterna."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU svarar inte. Kontrollera kablarna och kontakterna."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1633
+#: ../../Firmware/ultralcd.cpp:1629
 msgid "MMU connected"
 msgstr "MMU ansluten"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
 msgid "Magnets comp."
 msgstr "Magnets komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
-#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
-#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
-#: ../../Firmware/ultralcd.cpp:5435
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
+#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
+#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
+#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
+#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Main"
 msgstr "Huvudmeny"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2495
+#: ../../Firmware/ultralcd.cpp:2491
 msgid "Measured skew"
 msgstr "Mätt skevhet"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3246
-#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
+#: ../../Firmware/Marlin_main.cpp:3155
+#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Mätning av referenshöjd för kalibreringspunkt"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
 msgid "Mesh"
 msgstr "Nätverk"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
-#: ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
+#: ../../Firmware/ultralcd.cpp:4570
 msgid "Mesh Bed Leveling"
 msgstr "Bäddytsjustering"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
-#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
+#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/ultralcd.cpp:5555
 msgid "Mode"
 msgstr "Mode"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3410
+#: ../../Firmware/ultralcd.cpp:3399
 msgid "Mode change in progress..."
 msgstr "Lägesändring pågår..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4302
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
-#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
-#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
-#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
-#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
-#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
-#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
-#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
-#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
-#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
-#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
-#: ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
+#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
+#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
+#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
+#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
+#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
+#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
+#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
+#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
+#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
+#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
+#: ../../Firmware/mmu2/errors_list.h:331
 msgid "More details online."
 msgstr "Mera detaljer online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
-#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
+#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3334
+#: ../../Firmware/ultralcd.cpp:3323
 msgid "Move X"
 msgstr "Flytta X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3335
+#: ../../Firmware/ultralcd.cpp:3324
 msgid "Move Y"
 msgstr "Flytta Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3336
+#: ../../Firmware/ultralcd.cpp:3325
 msgid "Move Z"
 msgstr "Flytta Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/ultralcd.cpp:4442
 msgid "Move axis"
 msgstr "Flytta axlar"
 
@@ -1266,95 +1269,96 @@ msgid "Moving selector"
 msgstr "Flyttar väljare"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
-#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
-#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
-#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
+#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
+#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
+#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
+#: ../../Firmware/ultralcd.cpp:5528
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:209
 msgid "New firmware version available:"
 msgstr "Ny firmware vers tillgänglig:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
-#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
-#: ../../Firmware/ultralcd.cpp:5676
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
+#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/ultralcd.cpp:5693
 msgid "No"
 msgstr "Nej"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5257
+#: ../../Firmware/ultralcd.cpp:5263
 msgid "No SD card"
 msgstr "Inget SD-kort"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5291
+#: ../../Firmware/Marlin_main.cpp:5181
 msgid "No move."
 msgstr "Ingen rörelse."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
-#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
+#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
 msgid "None"
 msgstr "Ingen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
+#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6593
+#: ../../Firmware/ultralcd.cpp:6610
 msgid "Not connected"
 msgstr "Inte ansluten"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
 msgid "Not spinning"
 msgstr "Roterar inte"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3723
+#: ../../Firmware/ultralcd.cpp:3712
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Nu ska jag kalibrera avståndet mellan munstyckets spets och värmebäddsytan."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3868
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nu ska jag förvärma munstycket för PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3854
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "Now remove the test print from steel sheet."
 msgstr "Ta nu bort testutskriften från metallskivan."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
-#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
-#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
+#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
+#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4222
 msgid "Nozzle"
 msgstr "Munstycke"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
-#: ../../Firmware/ultralcd.cpp:4480
+#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
+#: ../../Firmware/ultralcd.cpp:4469
 msgid "Nozzle change"
 msgstr "Munstycksbyte"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
-#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
-#: ../../Firmware/ultralcd.cpp:4274
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
+#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
+#: ../../Firmware/ultralcd.cpp:4263
 msgid "Nozzle d."
 msgstr "Munst dia."
 
@@ -1365,81 +1369,81 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
-#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
-#: ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
+#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/ultralcd.cpp:7409
 msgid "Off"
 msgstr "Av"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1508
+#: ../../Firmware/Marlin_main.cpp:1503
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Gamla inställningar funna. Standard PID, Esteps etc. kommer att ställas in."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
-#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
-#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
-#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
-#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
-#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
-#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
+#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
+#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
 msgid "On"
 msgstr "På"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
 msgid "Once"
 msgstr "En gång"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSAT TERMISKT FEL"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:877
+#: ../../Firmware/ultralcd.cpp:875
 msgid "PID cal."
 msgstr "PID kalibrering."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:882
+#: ../../Firmware/ultralcd.cpp:880
 msgid "PID cal. finished"
 msgstr "PID kalibrering klar"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4586
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "PID calibration"
 msgstr "PID kalibrering"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:604
+#: ../../Firmware/ultralcd.cpp:603
 msgid "PINDA Heating"
 msgstr "PINDA uppvärmning"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
-#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
+#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3218
+#: ../../Firmware/ultralcd.cpp:3207
 msgid "PINDA calibration failed"
 msgstr "PINDA-kalibrering misslyckades"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:3215
+#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:3204
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1448,7 +1452,7 @@ msgstr ""
 "menyn Inställningar->PINDA kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "PULLEY CANNOT MOVE"
 msgstr "REMSKIVA FASTNAT"
 
@@ -1459,13 +1463,13 @@ msgid "Parking selector"
 msgstr "Parkerar väljare"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
 msgid "Pause"
 msgstr "Paus"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
-#: ../../Firmware/ultralcd.cpp:5218
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
+#: ../../Firmware/ultralcd.cpp:5216
 msgid "Pause print"
 msgstr "Pausa utskrift"
 
@@ -1476,7 +1480,7 @@ msgid "Performing cut"
 msgstr "Utför skärning"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
+#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1485,7 +1489,7 @@ msgstr ""
 "punkterna. Om munstycket fångar papperet, stäng av omedelbart."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1494,27 +1498,27 @@ msgstr ""
 "starta om skrivaren."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5910
+#: ../../Firmware/ultralcd.cpp:5927
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Kontrollera IR-sensorns anslutning, mata ut eventuellt filament."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6587
+#: ../../Firmware/ultralcd.cpp:6604
 msgid "Please check:"
 msgstr "Kontrollera:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/ultralcd.cpp:3912
 msgid "Please clean heatbed and then press the knob."
 msgstr "Rengör bädden och tryck sedan på knappen."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
+#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Rengör munstycket för kalibrering. Klicka när du är klar."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3709
+#: ../../Firmware/ultralcd.cpp:3698
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1522,7 +1526,7 @@ msgstr ""
 "inladdning.."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3702
+#: ../../Firmware/ultralcd.cpp:3691
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1531,104 +1535,104 @@ msgstr ""
 "knappen för inladdning."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3630
+#: ../../Firmware/ultralcd.cpp:3619
 msgid "Please load filament first."
 msgstr "Vänligen ladda filament först."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3553
+#: ../../Firmware/Marlin_main.cpp:3462
 msgid "Please open idler and remove filament manually."
 msgstr "Öppna idler och ta bort filamentet manuellt."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
+#: ../../Firmware/ultralcd.cpp:3846
 msgid "Please place steel sheet on heatbed."
 msgstr "Placera metallskiva på värmebädden."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
-#: ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
+#: ../../Firmware/messages.cpp:83
 msgid "Please press the knob to unload filament"
 msgstr "Vänligen tryck på knappen för att mata ut filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
 msgid "Please pull out filament immediately"
 msgstr "Vänligen ta ut filamentet omedelbart"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3853
+#: ../../Firmware/ultralcd.cpp:3842
 msgid "Please remove shipping helpers first."
 msgstr "Vänligen ta bort fraktinsatserna först."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
-#: ../../Firmware/messages.cpp:84
+#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
+#: ../../Firmware/messages.cpp:88
 msgid "Please remove steel sheet from heatbed."
 msgstr "Ta bort metallskivan från värmebädden."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4732
+#: ../../Firmware/Marlin_main.cpp:4641
 msgid "Please run XYZ calibration first."
 msgstr "Utför XYZ-kalibrering först."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5907
+#: ../../Firmware/ultralcd.cpp:5924
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vänligen mata ut filamentet först och upprepa sedan denna åtgärd."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:217
+#: ../../Firmware/util.cpp:213
 msgid "Please upgrade."
 msgstr "Vänligen uppgradera."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
-#: ../../Firmware/ultralcd.cpp:2166
+#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
+#: ../../Firmware/ultralcd.cpp:2162
 msgid "Please wait"
 msgstr "Vänligen vänta"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/ultralcd.cpp:1233
 msgid "Power failures"
 msgstr "Strömavbrott"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5211
+#: ../../Firmware/ultralcd.cpp:5209
 msgid "Preheat"
 msgstr "Förvärm"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
 msgid "Preheat the nozzle!"
 msgstr "Förvärm munstycket!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
-#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
+#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
 msgid "Preheating nozzle. Please wait."
 msgstr "Förvärmer munstycke. Vänta."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1975
+#: ../../Firmware/ultralcd.cpp:1971
 msgid "Preheating to cut"
 msgstr "Förvärmer för skära"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1972
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to eject"
 msgstr "Förvämer för utmatn"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1963
+#: ../../Firmware/ultralcd.cpp:1959
 msgid "Preheating to load"
 msgstr "Förvärmer för laddn"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1964
 msgid "Preheating to unload"
 msgstr "Förvärmer for utmatn"
 
@@ -1639,48 +1643,48 @@ msgid "Preparing blade"
 msgstr "Förbereder blad"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1775
+#: ../../Firmware/ultralcd.cpp:1771
 msgid "Press the knob"
 msgstr "Tryck på knappen"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10903
+#: ../../Firmware/Marlin_main.cpp:10818
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Tryck på knappen för att förvärma munstycket och fortsätta."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
 msgid "Print aborted"
 msgstr "Utskriften avbröts"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
+#: ../../Firmware/ultralcd.cpp:6898
 msgid "Print fan:"
 msgstr "Utskriftsfläkt:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
 msgid "Print from SD"
 msgstr "Skriv ut från SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:796
+#: ../../Firmware/ultralcd.cpp:794
 msgid "Print paused"
 msgstr "Utskriften pausad"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2324
+#: ../../Firmware/ultralcd.cpp:2320
 msgid "Print time"
 msgstr "Utskriftstid"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1665
+#: ../../Firmware/ultralcd.cpp:1661
 msgid "Printer IP Addr:"
 msgstr "Skrivarens IP adr:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
+#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1689,12 +1693,12 @@ msgstr ""
 "stegen, avsnitt Kalibreringsflöde."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
+#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Munstycksdiametern skiljer sig från G-codeen. Fortsätta?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
+#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1703,7 +1707,7 @@ msgstr ""
 "inställningarna. Utskriften avbröts."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Remskivans motor stannade. Se till att remskivan kan röra sig och "
@@ -1716,32 +1720,32 @@ msgid "Pushing filament"
 msgstr "Pressar filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "QUEUE FULL"
 msgstr "KÖ FULL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2688
+#: ../../Firmware/ultralcd.cpp:2684
 msgid "Rear side [µm]"
 msgstr "Baksida [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:322
+#: ../../Firmware/power_panic.cpp:323
 msgid "Recovering print"
 msgstr "Återställer utskrift"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5135
+#: ../../Firmware/ultralcd.cpp:5122
 msgid "Rename"
 msgstr "Döp om"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1750,24 +1754,24 @@ msgstr ""
 "G-codeen för verktygsindex utanför intervallet (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
-#: ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
+#: ../../Firmware/ultralcd.cpp:5123
 msgid "Reset"
 msgstr "Återställ"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Reset XYZ calibr."
 msgstr "Återställ XYZ-kal."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
-#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
+#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
+#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
 msgid "Resume print"
 msgstr "Återuppta utskrift"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
 msgid "Resuming print"
 msgstr "Återupptar utskrift"
 
@@ -1778,7 +1782,7 @@ msgid "Retract from FINDA"
 msgstr "Dra in från FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
 msgid "Retry"
 msgstr "Igen"
 
@@ -1789,17 +1793,17 @@ msgid "Returning selector"
 msgstr "Återvändande väljare"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2455
+#: ../../Firmware/ultralcd.cpp:2451
 msgid "Right"
 msgstr "Höger"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2686
+#: ../../Firmware/ultralcd.cpp:2682
 msgid "Right side[µm]"
 msgstr "Höger sida[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3653
+#: ../../Firmware/ultralcd.cpp:3642
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1808,39 +1812,39 @@ msgstr ""
 "börja om från början. Fortsätta?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
-#: ../../Firmware/ultralcd.cpp:4505
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
+#: ../../Firmware/ultralcd.cpp:4494
 msgid "SD card"
 msgstr "SD-kort"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT HOME"
 msgstr "VÄLJARE FASTNAT"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
 msgid "SELECTOR CANNOT MOVE"
 msgstr "VÄLJARE FASTNAT"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
+#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
 msgid "STOPPED."
 msgstr "STOPPAD."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
-#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
+#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
+#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Söker efter kalibreringspunkt för bädden"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5128
+#: ../../Firmware/ultralcd.cpp:5115
 msgid "Select"
 msgstr "Välj"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3727
+#: ../../Firmware/ultralcd.cpp:3716
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1848,25 +1852,25 @@ msgstr ""
 "Välj ett filament för första lagrets kalibrering och välj det i skärmmenyn."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
-#: ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:6726
 msgid "Select filament:"
 msgstr "Välj filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
-#: ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/ultralcd.cpp:4487
 msgid "Select language"
 msgstr "Välj språk"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3897
+#: ../../Firmware/ultralcd.cpp:3886
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Välj munstycksförvärmningstemperatur som passar ditt material."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3732
+#: ../../Firmware/ultralcd.cpp:3721
 msgid "Select temperature which matches your material."
 msgstr "Välj temperatur som passar ditt material."
 
@@ -1877,73 +1881,73 @@ msgid "Selecting fil. slot"
 msgstr "Välj fil. spår"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6161
+#: ../../Firmware/ultralcd.cpp:6178
 msgid "Self test OK"
 msgstr "Självtest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5944
+#: ../../Firmware/ultralcd.cpp:5961
 msgid "Self test start"
 msgstr "Självteststart"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4564
 msgid "Selftest"
 msgstr "Självtest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6586
+#: ../../Firmware/ultralcd.cpp:6603
 msgid "Selftest error!"
 msgstr "Självtestfel!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
-#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
 msgid "Selftest failed"
 msgstr "Självtestet felade"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1523
+#: ../../Firmware/Marlin_main.cpp:1518
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Självtest kommer att utföras för att kalibrera exakt sensorlös hemposition."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1677
+#: ../../Firmware/ultralcd.cpp:1673
 msgid "Sensor info"
 msgstr "Sensorinfo"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5914
+#: ../../Firmware/ultralcd.cpp:5931
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verifierad, ta bort filamentet nu."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2706
+#: ../../Firmware/ultralcd.cpp:2702
 msgid "Set temperature:"
 msgstr "Sätt temperatur:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
-#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
-#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
-#: ../../Firmware/ultralcd.cpp:5548
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
+#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
+#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "Settings"
 msgstr "Inställningar"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2498
+#: ../../Firmware/ultralcd.cpp:2494
 msgid "Severe skew"
 msgstr "Hög skevhet"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:64
+#: ../../Firmware/messages.cpp:68
 msgid "Sheet"
 msgstr "Skiva"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3601
+#: ../../Firmware/ultralcd.cpp:3590
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1956,23 +1960,23 @@ msgstr ""
 "%cÅterställ"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4588
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Show end stops"
 msgstr "Visa ändlägen"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
-#: ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
 msgid "Silent"
 msgstr "Tyst"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2493
 msgid "Slight skew"
 msgstr "Låg skevhet"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:814
+#: ../../Firmware/cardreader.cpp:815
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1981,125 +1985,125 @@ msgstr ""
 "sortering är 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3041
+#: ../../Firmware/Marlin_main.cpp:2978
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Ett problem har uppstått, Z-nivellering utförs..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
-#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
 msgid "Sort"
 msgstr "Sortera"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
-#: ../../Firmware/messages.cpp:101
+#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
+#: ../../Firmware/messages.cpp:105
 msgid "Sorting files"
 msgstr "Sorterar filer"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
-#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
+#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
 msgid "Sound"
 msgstr "Ljud"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5436
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Speed"
 msgstr "Fart"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
 msgid "Spinning"
 msgstr "Rotation"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4745
+#: ../../Firmware/Marlin_main.cpp:4654
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabil omgivningstemperatur 21-26C krävs samt ett styvt stativ."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5306
+#: ../../Firmware/ultralcd.cpp:5311
 msgid "Statistics"
 msgstr "Statistik"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
-#: ../../Firmware/ultralcd.cpp:4138
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4127
 msgid "Stealth"
 msgstr "Tyst"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
-#: ../../Firmware/ultralcd.cpp:5125
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/ultralcd.cpp:5112
 msgid "Steel sheets"
 msgstr "Metallskivor"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Stop"
 msgstr "Stopp"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
-#: ../../Firmware/ultralcd.cpp:5668
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
+#: ../../Firmware/ultralcd.cpp:5685
 msgid "Stop print"
 msgstr "Stoppa utskriften"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
+#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5320
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6645
+#: ../../Firmware/ultralcd.cpp:6662
 msgid "Swapped"
 msgstr "Utbytt"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
+#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
 msgid "THERMAL ANOMALY"
 msgstr "TERMISK ANOMALI"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
-#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
+#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
+#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
 msgid "TMC DRIVER ERROR"
 msgstr "TMC DRIVER FEL"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
-#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
+#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
+#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
 msgid "TMC DRIVER RESET"
 msgstr "TMC DRIVER RESET"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
-#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
+#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
+#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRIVER KORTSLUTN"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
-#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
+#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
+#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC ÖVERHETTNINGSFEL"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
-#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
+#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
+#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERSPÄNNINGFEL"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3878
+#: ../../Firmware/ultralcd.cpp:3867
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2108,27 +2112,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
+#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
 msgid "Thermal model not calibrated yet."
 msgstr "Termisk-modellen är inte kalibrerad ännu."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4449
+#: ../../Firmware/ultralcd.cpp:4438
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1683
+#: ../../Firmware/ultralcd.cpp:1679
 msgid "Temperatures"
 msgstr "Temperaturer"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
 msgid "Testing filament"
 msgstr "Testar filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
+#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2136,7 +2140,7 @@ msgstr ""
 "blockerar dess rörelse."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2144,7 +2148,7 @@ msgstr ""
 "blockerar dess rörelse."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/ultralcd.cpp:3724
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2154,7 +2158,7 @@ msgstr ""
 "optimal höjd. Kontrollera med bilderna i handboken (Kalibreringskapitlet)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
+#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2163,63 +2167,63 @@ msgstr ""
 "kap Första stegen, avs Kalibreringsflöde."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
 msgid "Time"
 msgstr "Tid"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
-#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
+#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
 msgid "Total failures"
 msgstr "Totala fel"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2345
+#: ../../Firmware/ultralcd.cpp:2341
 msgid "Total filament"
 msgstr "Total filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2346
+#: ../../Firmware/ultralcd.cpp:2342
 msgid "Total print time"
 msgstr "Tot utskriftstid"
 
-#. MSG_BTN_TUNE_MMU c=8
-#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
-#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
+#. MSG_TUNE c=8
+#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Tune"
 msgstr "Ställ in"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "UNLOAD MANUALLY"
 msgstr "LADDA UR MANUELLT"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Unload"
 msgstr "Ladda ur"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
-#: ../../Firmware/ultralcd.cpp:5299
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
+#: ../../Firmware/ultralcd.cpp:5304
 msgid "Unload filament"
 msgstr "Ta bort filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4907
+#: ../../Firmware/ultralcd.cpp:4894
 msgid "Unloading filament"
 msgstr "Tar bort filament"
 
@@ -2236,23 +2240,23 @@ msgid "Unloading to pulley"
 msgstr "Ladd ur t. remskiva"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5917
+#: ../../Firmware/ultralcd.cpp:5934
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifieringen felade, ta bort filamentet, försök igen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1686
+#: ../../Firmware/ultralcd.cpp:1682
 msgid "Voltages"
 msgstr "Spänning"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
-#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
+#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
+#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
 msgid "WARNING TMC TOO HOT"
 msgstr "VARNING TMC FÖR VARM"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3376
+#: ../../Firmware/ultralcd.cpp:3365
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2265,196 +2269,190 @@ msgstr ""
 "tyst-läge"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5260
+#: ../../Firmware/Marlin_main.cpp:5150
 msgid "Wait for user..."
 msgstr "Väntar på användare."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:2726
 msgid "Waiting for PINDA probe cooling"
 msgstr "Väntar på PINDA-sondens kylning"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2760
+#: ../../Firmware/ultralcd.cpp:2756
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Väntar på munstycks- och bäddkylning"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
-#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
+#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
 msgid "Warn"
 msgstr "Varna"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1500
+#: ../../Firmware/Marlin_main.cpp:1495
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Varning: både skrivartyp och moderkortstyp har ändrats."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1492
+#: ../../Firmware/Marlin_main.cpp:1487
 msgid "Warning: motherboard type changed."
 msgstr "Varning: moderkortstyp ändrad."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1496
+#: ../../Firmware/Marlin_main.cpp:1491
 msgid "Warning: printer type changed."
 msgstr "Varning: skrivartyp ändrats."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3546
+#: ../../Firmware/Marlin_main.cpp:3455
 msgid "Was filament unload successful?"
 msgstr "Lyckades filamentutmatningen?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
-#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
-#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
+#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
+#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
 msgid "Wiring error"
 msgstr "Kabelfel"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/ultralcd.cpp:4555
 msgid "Wizard"
 msgstr "Guide"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3983
+#: ../../Firmware/ultralcd.cpp:3972
 msgid "X-correct"
 msgstr "X-korrektion"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1675
+#: ../../Firmware/ultralcd.cpp:1671
 msgid "XYZ cal. details"
 msgstr "XYZ kal. detaljer"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3192
+#: ../../Firmware/ultralcd.cpp:3181
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ-kalibrering ok. Skevhet kommer att korrigeras automatiskt."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3189
+#: ../../Firmware/ultralcd.cpp:3178
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ-kalibrering ok. X/Y-axlarna är mycket lite skeva. Bra jobbat!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3170
+#: ../../Firmware/ultralcd.cpp:3159
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ-kalibrering komprometterad. Främre kalibreringspunkt kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/ultralcd.cpp:3162
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-kalibrering komprometterad. Främre hö kalibreringspunkter kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3152
+#: ../../Firmware/ultralcd.cpp:3141
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-kalibrering felade. Kalibreringspunkter ej funna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3158
+#: ../../Firmware/ultralcd.cpp:3147
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ-kalibrering felade. Främre kalibreringspunkt kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
-#: ../../Firmware/ultralcd.cpp:3183
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
+#: ../../Firmware/ultralcd.cpp:3172
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-kalibrering felade. Se bruksanvisningen."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3161
+#: ../../Firmware/ultralcd.cpp:3150
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ-kalibrering felade. Höger främre kalibreringspunkt kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3186
+#: ../../Firmware/ultralcd.cpp:3175
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-kalibrering ok. X/Y-axlarna ar vinkelräta. Grattis!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2452
+#: ../../Firmware/ultralcd.cpp:2448
 msgid "Y distance from min"
 msgstr "Y avstånd från min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3984
+#: ../../Firmware/ultralcd.cpp:3973
 msgid "Y-correct"
 msgstr "Y-korrekt"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
-#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
-#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
+#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
+#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Du kan alltid återuppta guiden från Kalibrering -> Guide."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3985
+#: ../../Firmware/ultralcd.cpp:3974
 msgid "Z-correct"
 msgstr "Z-korrekt"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
 msgid "Z-probe nr."
 msgstr "Z-sond nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/ultralcd.cpp:2518
 msgid "[0;0] point offset"
 msgstr "[0;0] punktförskjutn"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2123
+#: ../../Firmware/ultralcd.cpp:2119
 msgid "and press the knob"
 msgstr "och tryck på knapp"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1779
 msgid "to load filament"
 msgstr "att ladda filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1787
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to unload filament"
 msgstr "att ta bort filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1642
+#: ../../Firmware/ultralcd.cpp:1638
 msgid "unknown"
 msgstr "okänd"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
 msgid "unknown state"
 msgstr "okänt stat"
 
-#. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5748
-msgid "🔃Refresh"
-msgstr "🔃Uppdatera"
-
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
 msgid "MMU power fails"
 msgstr "MMU strömavbr."
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT UTASTAT"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2463,12 +2461,12 @@ msgstr ""
 "Kontrollera sensorerna och kablarna."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
 msgid "LOAD TO EXTR. FAILED"
 msgstr "MISLUKT LADDA EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2477,28 +2475,28 @@ msgstr ""
 "Förfina sensorkalibreringen vid behov."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU FEL"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1176
 msgid "Material changes"
 msgstr "Materialutbyten"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Ta bort den utskjutna filament från framsidan av MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2507,7 +2505,7 @@ msgstr ""
 "till att inget glödtråd är i väljaren och att FINDA fungerar korrekt."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2515,55 +2513,47 @@ msgstr ""
 "version 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
 msgid "Preload to MMU"
 msgstr "Förladdning MMU"
 
-#. MSG_FW_MK3_DETECTED c=20 r=4
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "MK3-firmware upptäckt på MK3S-skrivare"
-
-#. MSG_FW_MK3S_DETECTED c=20 r=4
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "MK3S-firmware upptäckt på MK3-skrivare"
-
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
 msgid "UNKNOWN ERROR"
 msgstr "OKÄNT FEL"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
 msgid "Unexpected error occurred."
 msgstr "Ett oväntat fel inträffade."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
 msgid "Eject"
 msgstr "Mata ut"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "FILAMENT CHANGE"
 msgstr "FILAMENTBYTE"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Load"
 msgstr "Ladda"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "M600 filamentbyte. Ladda en ny filament eller mata ut den gamla."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:426
+#: ../../Firmware/mmu2_reporting.cpp:444
 msgid "Sensitivity"
 msgstr "Känslighet"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2976
+#: ../../Firmware/Marlin_main.cpp:2973
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Bäddnivelleringen felade. Kör Z-kalibrering."
 
@@ -2578,9 +2568,18 @@ msgid "Set not Ready"
 msgstr "Set inte klart"
 
 #. MSG_REPRINT c=7
-#: ../../Firmware/ultralcd.cpp:5189
+#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Omtryck"
+
+#~ msgid "🔃Refresh"
+#~ msgstr "🔃Uppdatera"
+
+#~ msgid "MK3 firmware detected on MK3S printer"
+#~ msgstr "MK3-firmware upptäckt på MK3S-skrivare"
+
+#~ msgid "MK3S firmware detected on MK3 printer"
+#~ msgstr "MK3S-firmware upptäckt på MK3-skrivare"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamla fil. och tryck på knappen för att börja ladda nytt."

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2577,6 +2577,11 @@ msgstr "Gör klar"
 msgid "Set not Ready"
 msgstr "Set inte klart"
 
+#. MSG_REPRINT c=7
+#: ../../Firmware/ultralcd.cpp:5189
+msgid "Reprint"
+msgstr "Omtryck"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamla fil. och tryck på knappen för att börja ladda nytt."
 

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2567,7 +2567,7 @@ msgstr "Gör klar"
 msgid "Set not Ready"
 msgstr "Set inte klart"
 
-#. MSG_REPRINT c=7
+#. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
 msgstr "Omtryck"

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -17,91 +17,90 @@ msgstr ""
 
 #. MSG_IR_03_OR_OLDER c=18
 #: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:177
+#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:173
 msgid " 0.3 or older"
 msgstr " 0.3 el äldre"
 
 #. MSG_IR_04_OR_NEWER c=18
 #: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:176
+#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:172
 msgid " 0.4 or newer"
 msgstr " 0.4 el nyare"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:6677
+#: ../../Firmware/ultralcd.cpp:6660
 msgid "%s level expected"
 msgstr "%s nivå förväntad"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1950
-#: ../../Firmware/ultralcd.cpp:3599
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1954
+#: ../../Firmware/ultralcd.cpp:3610
 msgid ">Cancel"
 msgstr ">Avbryt"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/ultralcd.cpp:2607
+#: ../../Firmware/ultralcd.cpp:2611
 msgid "Adjusting Z"
 msgstr "Justerar Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:6887
+#: ../../Firmware/ultralcd.cpp:6868
 msgid "All correct"
 msgstr "Allt korrekt"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3941
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:3952
 msgid "All is done. Happy printing!"
 msgstr "Allt är klart. God utskrift!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4509
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4072
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4083
 msgid "Always"
 msgstr "Alltid"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1365
+#: ../../Firmware/ultralcd.cpp:1367
 msgid "Ambient"
 msgstr "Omgivande"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2822
+#: ../../Firmware/ultralcd.cpp:2826
 msgid "Are left and right Z-carriages all up?"
 msgstr "Är båda Z-vagnarna helt uppe?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4191
 msgid "Assist"
 msgstr "Assist"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5538
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3134 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4560 ../../Firmware/ultralcd.cpp:5351
-#: ../../Firmware/ultralcd.cpp:5463
+#: ../../Firmware/Marlin_main.cpp:3225 ../../Firmware/messages.cpp:9
+#: ../../Firmware/ultralcd.cpp:4573
 msgid "Auto home"
 msgstr "Auto hem"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:4141
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4152
 msgid "Auto power"
 msgstr "Auto kraft"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/ultralcd.cpp:5292
 msgid "AutoLoad filament"
 msgstr "Autoladda filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2245
+#: ../../Firmware/ultralcd.cpp:2249
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,52 +113,52 @@ msgid "Avoiding grind"
 msgstr "Undviker slipning"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:6656
+#: ../../Firmware/ultralcd.cpp:6639
 msgid "Axis"
 msgstr "Axel"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:6655
+#: ../../Firmware/ultralcd.cpp:6638
 msgid "Axis length"
 msgstr "Axellängd"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2680
-#: ../../Firmware/ultralcd.cpp:4023 ../../Firmware/ultralcd.cpp:5552
-#: ../../Firmware/ultralcd.cpp:7402
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:4034 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/ultralcd.cpp:7382
 msgid "Back"
 msgstr "Tillbaka"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2018 ../../Firmware/Marlin_main.cpp:4537
-#: ../../Firmware/Marlin_main.cpp:4588 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1363 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/Marlin_main.cpp:2023 ../../Firmware/Marlin_main.cpp:4628
+#: ../../Firmware/Marlin_main.cpp:4679 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:1365 ../../Firmware/ultralcd.cpp:4167
 msgid "Bed"
 msgstr "Bädd"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6028 ../../Firmware/messages.cpp:17
-#: ../../Firmware/ultralcd.cpp:527
+#: ../../Firmware/Marlin_main.cpp:6138 ../../Firmware/messages.cpp:14
+#: ../../Firmware/ultralcd.cpp:528
 msgid "Bed Heating"
 msgstr "Bädden värms upp"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6065 ../../Firmware/messages.cpp:16
-#: ../../Firmware/ultralcd.cpp:530
+#: ../../Firmware/Marlin_main.cpp:6169 ../../Firmware/messages.cpp:13
+#: ../../Firmware/ultralcd.cpp:531
 msgid "Bed done"
 msgstr "Bädd klar"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/ultralcd.cpp:4585
 msgid "Bed level correct"
 msgstr "Bäddnivå korrekt"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2199 ../../Firmware/Marlin_main.cpp:2934
-#: ../../Firmware/Marlin_main.cpp:2943
-#: ../../Firmware/mesh_bed_calibration.cpp:2880
-#: ../../Firmware/mesh_bed_calibration.cpp:2888
-#: ../../Firmware/mesh_bed_calibration.cpp:2914 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2204 ../../Firmware/Marlin_main.cpp:2974
+#: ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2864
+#: ../../Firmware/mesh_bed_calibration.cpp:2872
+#: ../../Firmware/mesh_bed_calibration.cpp:2898 ../../Firmware/messages.cpp:15
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -168,54 +167,54 @@ msgstr ""
 " på återställning."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6613
+#: ../../Firmware/ultralcd.cpp:6596
 msgid "Bed/Heater"
 msgstr "Bädd/Värmare"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1416
-#: ../../Firmware/ultralcd.cpp:1676
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1418
+#: ../../Firmware/ultralcd.cpp:1680
 msgid "Belt status"
 msgstr "Bält status"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4562
+#: ../../Firmware/ultralcd.cpp:4575
 msgid "Belt test"
 msgstr "Bält test"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1596 ../../Firmware/messages.cpp:86
+#: ../../Firmware/Marlin_main.cpp:1601 ../../Firmware/messages.cpp:82
 msgid "Blackout occurred. Recover print?"
 msgstr "Blackout inträffat. Återställa utskr?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:5538
 msgid "Bright"
 msgstr "Ljus"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:5480
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4520
+#: ../../Firmware/ultralcd.cpp:5464
 msgid "Brightness"
 msgstr "Ljusstyrka"
 
 #. MSG_TITLE_COMMUNICATION_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
+#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
 msgid "COMMUNICATION ERROR"
 msgstr "KOMMUNIKATIONSFEL"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4566
+#: ../../Firmware/ultralcd.cpp:4579
 msgid "Calibrate XYZ"
 msgstr "Kalibrera XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4568
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4581
 msgid "Calibrate Z"
 msgstr "Kalibrera Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2787
+#: ../../Firmware/ultralcd.cpp:2791
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -224,13 +223,13 @@ msgstr ""
 "Klicka när du är klar."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2155 ../../Firmware/messages.cpp:22
-#: ../../Firmware/ultralcd.cpp:575
+#: ../../Firmware/Marlin_main.cpp:2160 ../../Firmware/messages.cpp:19
+#: ../../Firmware/ultralcd.cpp:576
 msgid "Calibrating Z"
 msgstr "Kalibrerar Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2786
+#: ../../Firmware/ultralcd.cpp:2790
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -239,156 +238,156 @@ msgstr ""
 "Klicka när du är klar."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:6889
+#: ../../Firmware/ultralcd.cpp:6870
 msgid "Calibrating home"
 msgstr "Kalibrerar hem"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5307
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:5302
 msgid "Calibration"
 msgstr "Kalibrering"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/ultralcd.cpp:586
+#: ../../Firmware/ultralcd.cpp:587
 msgid "Calibration done"
 msgstr "Kalibraring utförd"
 
 #. MSG_DESC_CANNOT_MOVE c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:251 ../../Firmware/mmu2/errors_list.h:307
-#: ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:308
 msgid "Can't move Selector or Idler."
 msgstr "Kan inte flytta väljaren eller Idlern."
 
 #. MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
+#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
 msgid ""
 "Cannot perform the action, filament is already loaded. Unload it first."
 msgstr ""
 "Kan inte utföra åtgärden, filament är redan laddat. Ta bort det först."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7299
+#: ../../Firmware/ultralcd.cpp:7280
 msgid "Card removed"
 msgstr "Kort borttaget"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/ultralcd.cpp:5252
 msgid "Change SD card"
 msgstr "Byt ut SD-kort"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5204
-#: ../../Firmware/ultralcd.cpp:5460
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5206
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "Change filament"
 msgstr "Ändra filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2128
+#: ../../Firmware/ultralcd.cpp:2132
 msgid "Change success!"
 msgstr "Ändring utförd!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2175
+#: ../../Firmware/ultralcd.cpp:2179
 msgid "Changed correctly?"
 msgstr "Ändring korrekt?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5855
-#: ../../Firmware/ultralcd.cpp:6879
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
+#: ../../Firmware/ultralcd.cpp:6860
 msgid "Checking X axis"
 msgstr "Kontroll X-axel"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5865
-#: ../../Firmware/ultralcd.cpp:6880
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:5848
+#: ../../Firmware/ultralcd.cpp:6861
 msgid "Checking Y axis"
 msgstr "Kontroll Y-axel"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:6881
+#: ../../Firmware/ultralcd.cpp:6862
 msgid "Checking Z axis"
 msgstr "Kontroll Z-axel"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6882
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6863
 msgid "Checking bed"
 msgstr "Kontroll bädd"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6878
+#: ../../Firmware/ultralcd.cpp:6859
 msgid "Checking endstops"
 msgstr "Kontroll ändlägen"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/ultralcd.cpp:6955
 msgid "Checking file"
 msgstr "Kontrollerar fil"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:6884
+#: ../../Firmware/ultralcd.cpp:6865
 msgid "Checking hotend"
 msgstr "Kontroll hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6885
-#: ../../Firmware/ultralcd.cpp:6886
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6866
+#: ../../Firmware/ultralcd.cpp:6867
 msgid "Checking sensors"
 msgstr "Kontroll sensorer"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4407
+#: ../../Firmware/ultralcd.cpp:4418
 msgid "Checks"
 msgstr "Kontroller"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5239
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:5241
 msgid "Clear TM error"
 msgstr "Rensa TM-fel"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Color not correct"
 msgstr "Färg ej korrekt"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3505
 msgid "Community made"
 msgstr "Allmänhetsgjord"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4056
 msgid "Cont."
 msgstr "Frts."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2101
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2105
 msgid "Cooldown"
 msgstr "Kyla ner"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3436
+#: ../../Firmware/ultralcd.cpp:3447
 msgid "Copy selected language?"
 msgstr "Kopiera det valda språket?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1206
-#: ../../Firmware/ultralcd.cpp:1235
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1208
+#: ../../Firmware/ultralcd.cpp:1237
 msgid "Crash"
 msgstr "Krock"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4117
-#: ../../Firmware/ultralcd.cpp:4129
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4128
+#: ../../Firmware/ultralcd.cpp:4140
 msgid "Crash det."
 msgstr "Krockdetekt."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:567 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:571 ../../Firmware/messages.cpp:27
 msgid "Crash detected."
 msgstr "Krock upptäckt."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/ultralcd.cpp:3363
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -399,34 +398,34 @@ msgstr ""
 "normalt läge"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:366
-#: ../../Firmware/ultralcd.cpp:4837 ../../Firmware/ultralcd.cpp:5291
+#: ../../Firmware/messages.cpp:61 ../../Firmware/mmu2_reporting.cpp:348
+#: ../../Firmware/ultralcd.cpp:5286
 msgid "Cut filament"
 msgstr "Skär filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4072 ../../Firmware/ultralcd.cpp:4077
+#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4083 ../../Firmware/ultralcd.cpp:4088
 msgid "Cutter"
 msgstr "Skärare"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1617
+#: ../../Firmware/ultralcd.cpp:1621
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5538
 msgid "Dim"
 msgstr "Dim"
 
 #. MSG_BTN_DISABLE_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:361 ../../Firmware/mmu2/errors_list.h:374
+#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
 msgid "Disable"
 msgstr "Inaktiv."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4443
+#: ../../Firmware/ultralcd.cpp:4454
 msgid "Disable steppers"
 msgstr "Inaktivera stepper"
 
@@ -438,8 +437,8 @@ msgid "Disengaging idler"
 msgstr "Kopplar ur Idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1551 ../../Firmware/Marlin_main.cpp:3270
-#: ../../Firmware/messages.cpp:14
+#: ../../Firmware/Marlin_main.cpp:1556 ../../Firmware/Marlin_main.cpp:3361
+#: ../../Firmware/messages.cpp:11
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
 " Please follow the manual, chapter First steps, section First layer "
@@ -449,7 +448,7 @@ msgstr ""
 "Vänligen följ manualen Första lagrets kalibrering."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3909
+#: ../../Firmware/ultralcd.cpp:3920
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -457,14 +456,14 @@ msgstr ""
 "Vill du upprepa sista steget för justera avståndet mellan munstycket och "
 "bädden?"
 
-#. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:442
+#. MSG_BTN_DONE c=8
+#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2_reporting.cpp:424
 msgid "Done"
 msgstr "Klar"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3976
+#: ../../Firmware/ultralcd.cpp:3987
 msgid "E-correct"
 msgstr "E-korrektion"
 
@@ -493,13 +492,13 @@ msgid "ERR Wait for User"
 msgstr "FEL Inväntar anv"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2226
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2230
 msgid "ERROR:"
 msgstr "FEL:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:370
-#: ../../Firmware/ultralcd.cpp:4828 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:352
+#: ../../Firmware/ultralcd.cpp:5283
 msgid "Eject from MMU"
 msgstr "Utmat från MMU"
 
@@ -511,17 +510,17 @@ msgid "Ejecting filament"
 msgstr "Matar ut filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6609
 msgid "Endstop"
 msgstr "Ändläge"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6631
+#: ../../Firmware/ultralcd.cpp:6614
 msgid "Endstop not hit"
 msgstr "Ändlage inte nått"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6617
+#: ../../Firmware/ultralcd.cpp:6600
 msgid "Endstops"
 msgstr "Ändlägen"
 
@@ -533,45 +532,45 @@ msgid "Engaging idler"
 msgstr "Koppla in Idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3326
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:3337
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1672
+#: ../../Firmware/ultralcd.cpp:1676
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4030
-#: ../../Firmware/ultralcd.cpp:4037
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:4041
+#: ../../Firmware/ultralcd.cpp:4048
 msgid "F. autoload"
 msgstr "F. autoladdn"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:4039
+#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:4050
 msgid "F. jam detect"
 msgstr "F.stopp skett"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4036
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4047
 msgid "F. runout"
 msgstr "F. slut"
 
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
+#: ../../Firmware/mmu2/errors_list.h:181 ../../Firmware/mmu2/errors_list.h:228
 msgid "FIL. ALREADY LOADED"
 msgstr "F. REDAN INLADDAT"
 
 #. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
+#: ../../Firmware/mmu2/errors_list.h:138 ../../Firmware/mmu2/errors_list.h:192
 msgid "FINDA DIDNT TRIGGER"
 msgstr "FINDA TRIGGADES EJ"
 
 #. MSG_DESC_FINDA_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
+#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "FINDA didn't switch off while unloading filament. Try unloading manually. "
 "Ensure filament can move and FINDA works."
@@ -580,7 +579,7 @@ msgstr ""
 "manuellt. Se till att filamentet kan röra sig och att FINDA fungerar."
 
 #. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:242 ../../Firmware/mmu2/errors_list.h:298
+#: ../../Firmware/mmu2/errors_list.h:241 ../../Firmware/mmu2/errors_list.h:297
 msgid ""
 "FINDA didn't trigger while loading the filament. Ensure the filament can "
 "move and FINDA works."
@@ -589,65 +588,65 @@ msgstr ""
 "röra sig och att FINDA fungerar."
 
 #. MSG_TITLE_FINDA_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
+#: ../../Firmware/mmu2/errors_list.h:139 ../../Firmware/mmu2/errors_list.h:193
 msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. STOPP"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4045
-#: ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4056
+#: ../../Firmware/ultralcd.cpp:4059
 msgid "FS Action"
 msgstr "FS aktion"
 
 #. MSG_TITLE_FSENSOR_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
+#: ../../Firmware/mmu2/errors_list.h:140 ../../Firmware/mmu2/errors_list.h:194
 msgid "FSENSOR DIDNT TRIGG."
 msgstr "FSENSOR TRIGGADE EJ."
 
 #. MSG_TITLE_FSENSOR_TOO_EARLY c=20
-#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
+#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
 msgid "FSENSOR TOO EARLY"
 msgstr "FSENSOR FÖR TIDIG"
 
 #. MSG_TITLE_FSENSOR_FILAMENT_STUCK c=20
-#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
+#: ../../Firmware/mmu2/errors_list.h:141 ../../Firmware/mmu2/errors_list.h:195
 msgid "FSENSOR FIL. STUCK"
 msgstr "FSENSOR FIL. STOPP"
 
 #. MSG_TITLE_FW_RUNTIME_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
+#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
 msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME FEL"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5315
+#: ../../Firmware/ultralcd.cpp:5310
 msgid "Fail stats"
 msgstr "Felstatistik"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5318
+#: ../../Firmware/ultralcd.cpp:5313
 msgid "Fail stats MMU"
 msgstr "Felstatistik MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:6672
+#: ../../Firmware/ultralcd.cpp:6655
 msgid "False triggering"
 msgstr "Felaktig triggning"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:4169
 msgid "Fan speed"
 msgstr "Fläktfart"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6748
-#: ../../Firmware/ultralcd.cpp:6875 ../../Firmware/ultralcd.cpp:6876
-#: ../../Firmware/ultralcd.cpp:6877
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6731
+#: ../../Firmware/ultralcd.cpp:6856 ../../Firmware/ultralcd.cpp:6857
+#: ../../Firmware/ultralcd.cpp:6858
 msgid "Fan test"
 msgstr "Fläkttest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4162
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4173
 msgid "Fans check"
 msgstr "Fläktcheck"
 
@@ -676,46 +675,46 @@ msgid "Feeding to nozzle"
 msgstr "Matar till munstycke"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1205
-#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1288
-#: ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1207
+#: ../../Firmware/ultralcd.cpp:1236 ../../Firmware/ultralcd.cpp:1290
+#: ../../Firmware/ultralcd.cpp:1292
 msgid "Fil. runouts"
 msgstr "Fil. avbrott"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3287
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4447
-#: ../../Firmware/ultralcd.cpp:5466
+#: ../../Firmware/messages.cpp:47 ../../Firmware/ultralcd.cpp:3298
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4458
+#: ../../Firmware/ultralcd.cpp:5450
 msgid "Fil. sensor"
 msgstr "Fil. sensor"
 
 #. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3599
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3610
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2234
-#: ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2238
+#: ../../Firmware/ultralcd.cpp:2242
 msgid "Filament extruding & with correct color?"
 msgstr "Extruderas filament med rätt färg?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2177
+#: ../../Firmware/ultralcd.cpp:2181
 msgid "Filament not loaded"
 msgstr "Filament ej laddat"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6667
-#: ../../Firmware/ultralcd.cpp:6671 ../../Firmware/ultralcd.cpp:6675
-#: ../../Firmware/ultralcd.cpp:6904
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/ultralcd.cpp:6654 ../../Firmware/ultralcd.cpp:6658
+#: ../../Firmware/ultralcd.cpp:6885
 msgid "Filament sensor"
 msgstr "Filament sensor"
 
 #. MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
+#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
 msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
@@ -724,7 +723,7 @@ msgstr ""
 "filamentet kan röra sig och att sensorn fungerar."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:244 ../../Firmware/mmu2/errors_list.h:300
+#: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:299
 msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the sensor"
 " is calibrated and the filament reached it."
@@ -733,7 +732,7 @@ msgstr ""
 "filamentet kan röra sig och att sensorn fungerar."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
+#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
 msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
@@ -742,42 +741,42 @@ msgstr ""
 "extruder.Kontrollera PFFE-slang och att sensorn läser korrekt."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2319
+#: ../../Firmware/ultralcd.cpp:2323
 msgid "Filament used"
 msgstr "Använt filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7033
+#: ../../Firmware/ultralcd.cpp:7014
 msgid "File incomplete. Continue anyway?"
 msgstr "Filen är ofullständig. Fortsätta ändå?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:45
+#: ../../Firmware/messages.cpp:41
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5004 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5017 ../../Firmware/ultralcd.cpp:5348
 msgid "Finishing movements"
 msgstr "Avslutar flyttning"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:4558
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4571
+#: ../../Firmware/ultralcd.cpp:5133
 msgid "First layer cal."
 msgstr "Förstalager kalib."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3832
+#: ../../Firmware/ultralcd.cpp:3843
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Först kommer jag att utföra självtestet för att kontrollera de vanligaste "
 "monteringsproblemen."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5454
+#: ../../Firmware/ultralcd.cpp:5440
 msgid "Flow"
 msgstr "Flöde"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:188 ../../Firmware/ultralcd.cpp:961
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:963
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -786,28 +785,28 @@ msgstr ""
 " prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6637
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6620
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Front print fan?"
 msgstr "Frontfläkt?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2683
+#: ../../Firmware/ultralcd.cpp:2687
 msgid "Front side[µm]"
 msgstr "Frontsida[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:6661
+#: ../../Firmware/ultralcd.cpp:6644
 msgid "Front/left fans"
 msgstr "Front/vänster fläkt"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:145 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:386
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code genererad för en annan nivå. Fortsätta?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:387
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -816,14 +815,14 @@ msgstr ""
 "Utskriften avbröts."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:141 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:421
+#: ../../Firmware/messages.cpp:137 ../../Firmware/util.cpp:316
+#: ../../Firmware/util.cpp:425
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code genererad för en annan skrivartyp. Fortsätta?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:142 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:422
+#: ../../Firmware/messages.cpp:138 ../../Firmware/util.cpp:317
+#: ../../Firmware/util.cpp:426
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -832,12 +831,12 @@ msgstr ""
 "igen. Utskriften avbröts."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:139 ../../Firmware/util.cpp:366
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code genererad för en nyare firmware. Fortsätta?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:140 ../../Firmware/util.cpp:367
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -846,35 +845,35 @@ msgstr ""
 "Utskriften avbröts."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4366 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4377 ../../Firmware/ultralcd.cpp:4479
 msgid "HW Setup"
 msgstr "HW inställning"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6609
+#: ../../Firmware/ultralcd.cpp:6592
 msgid "Heater/Thermistor"
 msgstr "Värmare/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:5971 ../../Firmware/messages.cpp:52
-#: ../../Firmware/ultralcd.cpp:519
+#: ../../Firmware/Marlin_main.cpp:6081 ../../Firmware/messages.cpp:48
+#: ../../Firmware/ultralcd.cpp:520
 msgid "Heating"
 msgstr "Uppvärmning"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9317
+#: ../../Firmware/Marlin_main.cpp:9407
 msgid "Heating disabled by safety timer."
 msgstr "Uppvärmning avaktiverad av säkerhetstimer."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6002 ../../Firmware/messages.cpp:53
-#: ../../Firmware/ultralcd.cpp:522
+#: ../../Firmware/Marlin_main.cpp:6112 ../../Firmware/messages.cpp:49
+#: ../../Firmware/ultralcd.cpp:523
 msgid "Heating done."
 msgstr "Uppvärmning klar."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:3792
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:3803
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -885,7 +884,7 @@ msgstr ""
 "att skriva ut."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:3796
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3807
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -894,8 +893,8 @@ msgstr ""
 "installationsprocessen?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4135
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4155
 msgid "High power"
 msgstr "Hög kraft"
 
@@ -906,48 +905,48 @@ msgid "Homing"
 msgstr "Flyttar till hempos"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:189 ../../Firmware/ultralcd.cpp:981
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:983
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend temperatur är 280C! Är munstycket bytt och spänt enligt specs?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6895
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6876
 msgid "Hotend fan:"
 msgstr "Hotend-fläkt:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3837
+#: ../../Firmware/ultralcd.cpp:3848
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Jag kommer att utföra en xyz-kalibrering nu. Det tar upp till 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3848
+#: ../../Firmware/ultralcd.cpp:3859
 msgid "I will run z calibration now."
 msgstr "Jag kommer att utföra z-kalibrering nu."
 
 #. MSG_TITLE_IDLER_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:203
+#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:202
 msgid "IDLER CANNOT HOME"
 msgstr "IDLER HEMPOS FEL"
 
 #. MSG_TITLE_IDLER_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:149 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:203
 msgid "IDLER CANNOT MOVE"
 msgstr "IDLER KAN EJ FLYTTA"
 
 #. MSG_TITLE_INSPECT_FINDA c=20
-#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
+#: ../../Firmware/mmu2/errors_list.h:144 ../../Firmware/mmu2/errors_list.h:198
 msgid "INSPECT FINDA"
 msgstr "KONTROLLERA FINDA"
 
 #. MSG_TITLE_INVALID_TOOL c=20
-#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
+#: ../../Firmware/mmu2/errors_list.h:182 ../../Firmware/mmu2/errors_list.h:229
 msgid "INVALID TOOL"
 msgstr "OGILTIGT VERKTYG"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3917
+#: ../../Firmware/ultralcd.cpp:3928
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -956,27 +955,27 @@ msgstr ""
 "Inställningar - HW inställning - Metallskiva."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2546
+#: ../../Firmware/mesh_bed_calibration.cpp:2536
 msgid "Improving bed calibration point"
 msgstr "Förbättrar bäddens kalibreringspunkt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5174
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:5187
 msgid "Info screen"
 msgstr "Infoskärm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/ultralcd.cpp:5259
 msgid "Init. SD card"
 msgstr "Init. SD-kort"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2114
+#: ../../Firmware/ultralcd.cpp:2118
 msgid "Insert filament"
 msgstr "Sätt i filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:5902
+#: ../../Firmware/ultralcd.cpp:5885
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -985,280 +984,278 @@ msgstr ""
 "knappen."
 
 #. MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
+#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:337
 msgid ""
 "Internal runtime error. Try resetting the MMU or updating the firmware."
 msgstr "Internt körtidsfel. Prova återställa MMU eller uppdatera firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3614
-#: ../../Firmware/ultralcd.cpp:3876
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3625
+#: ../../Firmware/ultralcd.cpp:3887
 msgid "Is filament loaded?"
 msgstr "Är filament laddat?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3174 ../../Firmware/Marlin_main.cpp:4655
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:3844
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/Marlin_main.cpp:4746
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:3855
 msgid "Is steel sheet on heatbed?"
 msgstr "Ligger metallskiva på värmebädden?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2268 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2258 ../../Firmware/messages.cpp:51
 msgid "Iteration"
 msgstr "Iteration"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1100
-#: ../../Firmware/ultralcd.cpp:1258
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1102
+#: ../../Firmware/ultralcd.cpp:1260
 msgid "Last print"
 msgstr "Senaste utskrift"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1124
-#: ../../Firmware/ultralcd.cpp:1232 ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:1126
+#: ../../Firmware/ultralcd.cpp:1234 ../../Firmware/ultralcd.cpp:1289
 msgid "Last print failures"
 msgstr "Senaste utskriftsfel"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2450
+#: ../../Firmware/ultralcd.cpp:2454
 msgid "Left"
 msgstr "Vänster"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6643
-#: ../../Firmware/ultralcd.cpp:6754 ../../Firmware/ultralcd.cpp:6759
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:6626
+#: ../../Firmware/ultralcd.cpp:6737 ../../Firmware/ultralcd.cpp:6742
 msgid "Left hotend fan?"
 msgstr "Vänst hotend fläkt?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2681
+#: ../../Firmware/ultralcd.cpp:2685
 msgid "Left side [µm]"
 msgstr "Vänstsida [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5553
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:5536
 msgid "Level Bright"
 msgstr "Ljusnivå"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5554
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:5537
 msgid "Level Dimmed"
 msgstr "Nivå dämpad"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4474
+#: ../../Firmware/ultralcd.cpp:4485
 msgid "Lin. correction"
 msgstr "Linjär korrektion"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4484
-#: ../../Firmware/ultralcd.cpp:5201
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4495
+#: ../../Firmware/ultralcd.cpp:5203
 msgid "Live adjust Z"
 msgstr "Live justera Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:4777
-#: ../../Firmware/ultralcd.cpp:4863
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:4790
+#: ../../Firmware/ultralcd.cpp:4876
 msgid "Load All"
 msgstr "Ladda alla"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4779
-#: ../../Firmware/ultralcd.cpp:4816 ../../Firmware/ultralcd.cpp:4865
-#: ../../Firmware/ultralcd.cpp:5302
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:4792
+#: ../../Firmware/ultralcd.cpp:4878 ../../Firmware/ultralcd.cpp:5297
 msgid "Load filament"
 msgstr "Ladda filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5286
+#: ../../Firmware/ultralcd.cpp:5281
 msgid "Load to nozzle"
 msgstr "Ladd till munstyck"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:4470
 msgid "Loading Test"
 msgstr "Laddningstest"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2150
+#: ../../Firmware/ultralcd.cpp:2154
 msgid "Loading color"
 msgstr "Laddar färg"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3519 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3610 ../../Firmware/messages.cpp:58
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:378 ../../Firmware/ultralcd.cpp:2161
-#: ../../Firmware/ultralcd.cpp:3701
+#: ../../Firmware/mmu2_reporting.cpp:360 ../../Firmware/ultralcd.cpp:2165
+#: ../../Firmware/ultralcd.cpp:3712
 msgid "Loading filament"
 msgstr "Laddar filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:6649
+#: ../../Firmware/ultralcd.cpp:6632
 msgid "Loose pulley"
 msgstr "Lös pulley"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4194
 msgid "Loud"
 msgstr "Högt"
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20
-#: ../../Firmware/mmu2/errors_list.h:185 ../../Firmware/mmu2/errors_list.h:232
+#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
 msgid "MMU FW UPDATE NEEDED"
 msgstr "MMU FW UPDATE KRÄVS"
 
 #. MSG_DESC_QUEUE_FULL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:336
+#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware internt fel, vänligen återställ MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4093
 msgid "MMU Mode"
 msgstr "MMU-läge"
 
 #. MSG_TITLE_MMU_NOT_RESPONDING c=20
-#: ../../Firmware/mmu2/errors_list.h:180 ../../Firmware/mmu2/errors_list.h:227
+#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
 msgid "MMU NOT RESPONDING"
 msgstr "MMU SVARAR INTE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/mmu2_reporting.cpp:382
+#: ../../Firmware/mmu2_reporting.cpp:364
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU försök igen: Återställer temperatur..."
 
 #. MSG_TITLE_SELFTEST_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:175 ../../Firmware/mmu2/errors_list.h:223
-#: ../../Firmware/mmu2/errors_list.h:224 ../../Firmware/mmu2/errors_list.h:225
+#: ../../Firmware/mmu2/errors_list.h:174 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:223 ../../Firmware/mmu2/errors_list.h:224
 msgid "MMU SELFTEST FAILED"
 msgstr "MMU SJÄLVTEST FELADE"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1125
-#: ../../Firmware/ultralcd.cpp:1150
+#: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1127
+#: ../../Firmware/ultralcd.cpp:1152
 msgid "MMU fails"
 msgstr "MMU felar"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1126
-#: ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:1128
+#: ../../Firmware/ultralcd.cpp:1153
 msgid "MMU load fails"
 msgstr "MMU-laddn felar"
 
 #. MSG_DESC_COMMUNICATION_ERROR c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:279 ../../Firmware/mmu2/errors_list.h:333
+#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
 msgid "MMU not responding correctly. Check the wiring and connectors."
 msgstr "MMU svarar inte korrekt. Kontrollera kablarna och kontakterna."
 
 #. MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/mmu2/errors_list.h:278 ../../Firmware/mmu2/errors_list.h:332
+#: ../../Firmware/mmu2/errors_list.h:277 ../../Firmware/mmu2/errors_list.h:331
 msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU svarar inte. Kontrollera kablarna och kontakterna."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1629
+#: ../../Firmware/ultralcd.cpp:1633
 msgid "MMU connected"
 msgstr "MMU ansluten"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:5511
 msgid "Magnets comp."
 msgstr "Magnets komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1099
-#: ../../Firmware/ultralcd.cpp:1257 ../../Firmware/ultralcd.cpp:1299
-#: ../../Firmware/ultralcd.cpp:1603 ../../Firmware/ultralcd.cpp:4436
-#: ../../Firmware/ultralcd.cpp:4554 ../../Firmware/ultralcd.cpp:4776
-#: ../../Firmware/ultralcd.cpp:4809 ../../Firmware/ultralcd.cpp:4862
-#: ../../Firmware/ultralcd.cpp:5449
+#: ../../Firmware/messages.cpp:62 ../../Firmware/ultralcd.cpp:1101
+#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1301
+#: ../../Firmware/ultralcd.cpp:1605 ../../Firmware/ultralcd.cpp:4447
+#: ../../Firmware/ultralcd.cpp:4565 ../../Firmware/ultralcd.cpp:4789
+#: ../../Firmware/ultralcd.cpp:4822 ../../Firmware/ultralcd.cpp:4875
+#: ../../Firmware/ultralcd.cpp:5435
 msgid "Main"
 msgstr "Huvudmeny"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2491
+#: ../../Firmware/ultralcd.cpp:2495
 msgid "Measured skew"
 msgstr "Mätt skevhet"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3155
-#: ../../Firmware/mesh_bed_calibration.cpp:2858 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:3246
+#: ../../Firmware/mesh_bed_calibration.cpp:2842 ../../Firmware/messages.cpp:66
 msgid "Measuring reference height of calibration point"
 msgstr "Mätning av referenshöjd för kalibreringspunkt"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:5524
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5507
 msgid "Mesh"
 msgstr "Nätverk"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4471
-#: ../../Firmware/ultralcd.cpp:4570
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4482
+#: ../../Firmware/ultralcd.cpp:4583
 msgid "Mesh Bed Leveling"
 msgstr "Bäddytsjustering"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8194 ../../Firmware/messages.cpp:111
-#: ../../Firmware/ultralcd.cpp:4111 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4123 ../../Firmware/ultralcd.cpp:4127
-#: ../../Firmware/ultralcd.cpp:4135 ../../Firmware/ultralcd.cpp:4138
-#: ../../Firmware/ultralcd.cpp:4141 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:5555
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4134
+#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/ultralcd.cpp:4149 ../../Firmware/ultralcd.cpp:4152
+#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:5538
 msgid "Mode"
 msgstr "Mode"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3399
+#: ../../Firmware/ultralcd.cpp:3410
 msgid "Mode change in progress..."
 msgstr "Lägesändring pågår..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4299
-#: ../../Firmware/ultralcd.cpp:4302
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4310
+#: ../../Firmware/ultralcd.cpp:4313
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_DESC_TMC c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:255 ../../Firmware/mmu2/errors_list.h:310
-#: ../../Firmware/mmu2/errors_list.h:311 ../../Firmware/mmu2/errors_list.h:312
-#: ../../Firmware/mmu2/errors_list.h:313 ../../Firmware/mmu2/errors_list.h:314
-#: ../../Firmware/mmu2/errors_list.h:315 ../../Firmware/mmu2/errors_list.h:316
-#: ../../Firmware/mmu2/errors_list.h:317 ../../Firmware/mmu2/errors_list.h:318
-#: ../../Firmware/mmu2/errors_list.h:319 ../../Firmware/mmu2/errors_list.h:320
-#: ../../Firmware/mmu2/errors_list.h:321 ../../Firmware/mmu2/errors_list.h:322
-#: ../../Firmware/mmu2/errors_list.h:323 ../../Firmware/mmu2/errors_list.h:324
-#: ../../Firmware/mmu2/errors_list.h:325 ../../Firmware/mmu2/errors_list.h:326
-#: ../../Firmware/mmu2/errors_list.h:327 ../../Firmware/mmu2/errors_list.h:328
-#: ../../Firmware/mmu2/errors_list.h:329 ../../Firmware/mmu2/errors_list.h:330
-#: ../../Firmware/mmu2/errors_list.h:331
+#: ../../Firmware/mmu2/errors_list.h:254 ../../Firmware/mmu2/errors_list.h:309
+#: ../../Firmware/mmu2/errors_list.h:310 ../../Firmware/mmu2/errors_list.h:311
+#: ../../Firmware/mmu2/errors_list.h:312 ../../Firmware/mmu2/errors_list.h:313
+#: ../../Firmware/mmu2/errors_list.h:314 ../../Firmware/mmu2/errors_list.h:315
+#: ../../Firmware/mmu2/errors_list.h:316 ../../Firmware/mmu2/errors_list.h:317
+#: ../../Firmware/mmu2/errors_list.h:318 ../../Firmware/mmu2/errors_list.h:319
+#: ../../Firmware/mmu2/errors_list.h:320 ../../Firmware/mmu2/errors_list.h:321
+#: ../../Firmware/mmu2/errors_list.h:322 ../../Firmware/mmu2/errors_list.h:323
+#: ../../Firmware/mmu2/errors_list.h:324 ../../Firmware/mmu2/errors_list.h:325
+#: ../../Firmware/mmu2/errors_list.h:326 ../../Firmware/mmu2/errors_list.h:327
+#: ../../Firmware/mmu2/errors_list.h:328 ../../Firmware/mmu2/errors_list.h:329
+#: ../../Firmware/mmu2/errors_list.h:330
 msgid "More details online."
 msgstr "Mera detaljer online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6623
-#: ../../Firmware/ultralcd.cpp:6632 ../../Firmware/ultralcd.cpp:6650
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6606
+#: ../../Firmware/ultralcd.cpp:6615 ../../Firmware/ultralcd.cpp:6633
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:3334
 msgid "Move X"
 msgstr "Flytta X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/ultralcd.cpp:3335
 msgid "Move Y"
 msgstr "Flytta Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3325
+#: ../../Firmware/ultralcd.cpp:3336
 msgid "Move Z"
 msgstr "Flytta Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4442
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Move axis"
 msgstr "Flytta axlar"
 
@@ -1269,96 +1266,95 @@ msgid "Moving selector"
 msgstr "Flyttar väljare"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:135
-#: ../../Firmware/ultralcd.cpp:2456 ../../Firmware/ultralcd.cpp:2500
-#: ../../Firmware/ultralcd.cpp:3253 ../../Firmware/ultralcd.cpp:4029
-#: ../../Firmware/ultralcd.cpp:4030 ../../Firmware/ultralcd.cpp:4032
-#: ../../Firmware/ultralcd.cpp:5528
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:131
+#: ../../Firmware/ultralcd.cpp:2460 ../../Firmware/ultralcd.cpp:2504
+#: ../../Firmware/ultralcd.cpp:3264 ../../Firmware/ultralcd.cpp:4040
+#: ../../Firmware/ultralcd.cpp:4041 ../../Firmware/ultralcd.cpp:4043
+#: ../../Firmware/ultralcd.cpp:5511
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/util.cpp:209
+#: ../../Firmware/util.cpp:213
 msgid "New firmware version available:"
 msgstr "Ny firmware vers tillgänglig:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3003
-#: ../../Firmware/ultralcd.cpp:4426 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:5693
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:3012
+#: ../../Firmware/ultralcd.cpp:4437 ../../Firmware/ultralcd.cpp:4525
+#: ../../Firmware/ultralcd.cpp:5676
 msgid "No"
 msgstr "Nej"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/ultralcd.cpp:5257
 msgid "No SD card"
 msgstr "Inget SD-kort"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5181
+#: ../../Firmware/Marlin_main.cpp:5291
 msgid "No move."
 msgstr "Ingen rörelse."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4222 ../../Firmware/ultralcd.cpp:4293
-#: ../../Firmware/ultralcd.cpp:4302 ../../Firmware/ultralcd.cpp:4332
-#: ../../Firmware/ultralcd.cpp:4341 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4304
+#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4343
+#: ../../Firmware/ultralcd.cpp:4352 ../../Firmware/ultralcd.cpp:4510
 msgid "None"
 msgstr "Ingen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:115
-#: ../../Firmware/ultralcd.cpp:4082 ../../Firmware/ultralcd.cpp:4115
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4126 ../../Firmware/ultralcd.cpp:4505
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6610
+#: ../../Firmware/ultralcd.cpp:6593
 msgid "Not connected"
 msgstr "Inte ansluten"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6767
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:6750
 msgid "Not spinning"
 msgstr "Roterar inte"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/ultralcd.cpp:3723
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Nu ska jag kalibrera avståndet mellan munstyckets spets och värmebäddsytan."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/ultralcd.cpp:3868
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nu ska jag förvärma munstycket för PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3843
+#: ../../Firmware/ultralcd.cpp:3854
 msgid "Now remove the test print from steel sheet."
 msgstr "Ta nu bort testutskriften från metallskivan."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1362
-#: ../../Firmware/ultralcd.cpp:4153 ../../Firmware/ultralcd.cpp:4213
-#: ../../Firmware/ultralcd.cpp:4216 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4222
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1364
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4224
+#: ../../Firmware/ultralcd.cpp:4227 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "Nozzle"
 msgstr "Munstycke"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:187 ../../Firmware/ultralcd.cpp:4406
-#: ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:4417
+#: ../../Firmware/ultralcd.cpp:4480
 msgid "Nozzle change"
 msgstr "Munstycksbyte"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4259
-#: ../../Firmware/ultralcd.cpp:4261 ../../Firmware/ultralcd.cpp:4262
-#: ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4270
+#: ../../Firmware/ultralcd.cpp:4272 ../../Firmware/ultralcd.cpp:4273
+#: ../../Firmware/ultralcd.cpp:4274
 msgid "Nozzle d."
 msgstr "Munst dia."
 
@@ -1369,81 +1365,81 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:133
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4077
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5376
-#: ../../Firmware/ultralcd.cpp:5528 ../../Firmware/ultralcd.cpp:7405
-#: ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:129
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4088
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5362
+#: ../../Firmware/ultralcd.cpp:5511 ../../Firmware/ultralcd.cpp:7385
+#: ../../Firmware/ultralcd.cpp:7389
 msgid "Off"
 msgstr "Av"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1503
+#: ../../Firmware/Marlin_main.cpp:1508
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Gamla inställningar funna. Standard PID, Esteps etc. kommer att ställas in."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:134
-#: ../../Firmware/ultralcd.cpp:4025 ../../Firmware/ultralcd.cpp:4036
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4062 ../../Firmware/ultralcd.cpp:4067
-#: ../../Firmware/ultralcd.cpp:4117 ../../Firmware/ultralcd.cpp:4162
-#: ../../Firmware/ultralcd.cpp:4450 ../../Firmware/ultralcd.cpp:4478
-#: ../../Firmware/ultralcd.cpp:4481 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:7405 ../../Firmware/ultralcd.cpp:7409
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:130
+#: ../../Firmware/ultralcd.cpp:4036 ../../Firmware/ultralcd.cpp:4047
+#: ../../Firmware/ultralcd.cpp:4048 ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/ultralcd.cpp:4073 ../../Firmware/ultralcd.cpp:4078
+#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/ultralcd.cpp:4461 ../../Firmware/ultralcd.cpp:4489
+#: ../../Firmware/ultralcd.cpp:4492 ../../Firmware/ultralcd.cpp:5511
+#: ../../Firmware/ultralcd.cpp:7385 ../../Firmware/ultralcd.cpp:7389
 msgid "On"
 msgstr "På"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4174
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:4185
 msgid "Once"
 msgstr "En gång"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9496 ../../Firmware/messages.cpp:180
+#: ../../Firmware/Marlin_main.cpp:9586 ../../Firmware/messages.cpp:176
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSAT TERMISKT FEL"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/ultralcd.cpp:875
+#: ../../Firmware/ultralcd.cpp:877
 msgid "PID cal."
 msgstr "PID kalibrering."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/ultralcd.cpp:880
+#: ../../Firmware/ultralcd.cpp:882
 msgid "PID cal. finished"
 msgstr "PID kalibrering klar"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4573
+#: ../../Firmware/ultralcd.cpp:4586
 msgid "PID calibration"
 msgstr "PID kalibrering"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/ultralcd.cpp:603
+#: ../../Firmware/ultralcd.cpp:604
 msgid "PINDA Heating"
 msgstr "PINDA uppvärmning"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4700 ../../Firmware/Marlin_main.cpp:4802
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:600
-#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4580
+#: ../../Firmware/Marlin_main.cpp:4791 ../../Firmware/Marlin_main.cpp:4893
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:601
+#: ../../Firmware/ultralcd.cpp:4489 ../../Firmware/ultralcd.cpp:4593
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/ultralcd.cpp:3218
 msgid "PINDA calibration failed"
 msgstr "PINDA-kalibrering misslyckades"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4877 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/Marlin_main.cpp:4968 ../../Firmware/messages.cpp:117
+#: ../../Firmware/ultralcd.cpp:3215
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1452,7 +1448,7 @@ msgstr ""
 "menyn Inställningar->PINDA kal."
 
 #. MSG_TITLE_PULLEY_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:143 ../../Firmware/mmu2/errors_list.h:197
+#: ../../Firmware/mmu2/errors_list.h:142 ../../Firmware/mmu2/errors_list.h:196
 msgid "PULLEY CANNOT MOVE"
 msgstr "REMSKIVA FASTNAT"
 
@@ -1463,13 +1459,13 @@ msgid "Parking selector"
 msgstr "Parkerar väljare"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4048
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4059
 msgid "Pause"
 msgstr "Paus"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5214
-#: ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5218
 msgid "Pause print"
 msgstr "Pausa utskrift"
 
@@ -1480,7 +1476,7 @@ msgid "Performing cut"
 msgstr "Utför skärning"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3179 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:3270 ../../Firmware/messages.cpp:73
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1489,7 +1485,7 @@ msgstr ""
 "punkterna. Om munstycket fångar papperet, stäng av omedelbart."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:3960
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1498,27 +1494,27 @@ msgstr ""
 "starta om skrivaren."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:5910
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Kontrollera IR-sensorns anslutning, mata ut eventuellt filament."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6604
+#: ../../Firmware/ultralcd.cpp:6587
 msgid "Please check:"
 msgstr "Kontrollera:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3912
+#: ../../Firmware/ultralcd.cpp:3923
 msgid "Please clean heatbed and then press the knob."
 msgstr "Rengör bädden och tryck sedan på knappen."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3153 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:3244 ../../Firmware/messages.cpp:24
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Rengör munstycket för kalibrering. Klicka när du är klar."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:3709
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1526,7 +1522,7 @@ msgstr ""
 "inladdning.."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3691
+#: ../../Firmware/ultralcd.cpp:3702
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1535,104 +1531,104 @@ msgstr ""
 "knappen för inladdning."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3619
+#: ../../Firmware/ultralcd.cpp:3630
 msgid "Please load filament first."
 msgstr "Vänligen ladda filament först."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3462
+#: ../../Firmware/Marlin_main.cpp:3553
 msgid "Please open idler and remove filament manually."
 msgstr "Öppna idler och ta bort filamentet manuellt."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2816 ../../Firmware/messages.cpp:79
-#: ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/mesh_bed_calibration.cpp:2801 ../../Firmware/messages.cpp:75
+#: ../../Firmware/ultralcd.cpp:3857
 msgid "Please place steel sheet on heatbed."
 msgstr "Placera metallskiva på värmebädden."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10806 ../../Firmware/Marlin_main.cpp:10836
-#: ../../Firmware/messages.cpp:83
+#: ../../Firmware/Marlin_main.cpp:10891 ../../Firmware/Marlin_main.cpp:10921
+#: ../../Firmware/messages.cpp:79
 msgid "Please press the knob to unload filament"
 msgstr "Vänligen tryck på knappen för att mata ut filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:4928
 msgid "Please pull out filament immediately"
 msgstr "Vänligen ta ut filamentet omedelbart"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3842
+#: ../../Firmware/ultralcd.cpp:3853
 msgid "Please remove shipping helpers first."
 msgstr "Vänligen ta bort fraktinsatserna först."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3176 ../../Firmware/Marlin_main.cpp:4665
-#: ../../Firmware/messages.cpp:88
+#: ../../Firmware/Marlin_main.cpp:3267 ../../Firmware/Marlin_main.cpp:4756
+#: ../../Firmware/messages.cpp:84
 msgid "Please remove steel sheet from heatbed."
 msgstr "Ta bort metallskivan från värmebädden."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4641
+#: ../../Firmware/Marlin_main.cpp:4732
 msgid "Please run XYZ calibration first."
 msgstr "Utför XYZ-kalibrering först."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5924
+#: ../../Firmware/ultralcd.cpp:5907
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vänligen mata ut filamentet först och upprepa sedan denna åtgärd."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/util.cpp:213
+#: ../../Firmware/util.cpp:217
 msgid "Please upgrade."
 msgstr "Vänligen uppgradera."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3458 ../../Firmware/Marlin_main.cpp:7794
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2151
-#: ../../Firmware/ultralcd.cpp:2162
+#: ../../Firmware/Marlin_main.cpp:3549 ../../Firmware/Marlin_main.cpp:7892
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:2155
+#: ../../Firmware/ultralcd.cpp:2166
 msgid "Please wait"
 msgstr "Vänligen vänta"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:1204
-#: ../../Firmware/ultralcd.cpp:1233
+#: ../../Firmware/messages.cpp:77 ../../Firmware/ultralcd.cpp:1206
+#: ../../Firmware/ultralcd.cpp:1235
 msgid "Power failures"
 msgstr "Strömavbrott"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5209
+#: ../../Firmware/ultralcd.cpp:5211
 msgid "Preheat"
 msgstr "Förvärm"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:2227
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:2231
 msgid "Preheat the nozzle!"
 msgstr "Förvärm munstycket!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2744
-#: ../../Firmware/ultralcd.cpp:3676 ../../Firmware/ultralcd.cpp:3678
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:2748
+#: ../../Firmware/ultralcd.cpp:3687 ../../Firmware/ultralcd.cpp:3689
 msgid "Preheating nozzle. Please wait."
 msgstr "Förvärmer munstycke. Vänta."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1971
+#: ../../Firmware/ultralcd.cpp:1975
 msgid "Preheating to cut"
 msgstr "Förvärmer för skära"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1968
+#: ../../Firmware/ultralcd.cpp:1972
 msgid "Preheating to eject"
 msgstr "Förvämer för utmatn"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1959
+#: ../../Firmware/ultralcd.cpp:1963
 msgid "Preheating to load"
 msgstr "Förvärmer för laddn"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1964
+#: ../../Firmware/ultralcd.cpp:1968
 msgid "Preheating to unload"
 msgstr "Förvärmer for utmatn"
 
@@ -1643,48 +1639,48 @@ msgid "Preparing blade"
 msgstr "Förbereder blad"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1771
+#: ../../Firmware/ultralcd.cpp:1775
 msgid "Press the knob"
 msgstr "Tryck på knappen"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:10818
+#: ../../Firmware/Marlin_main.cpp:10903
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Tryck på knappen för att förvärma munstycket och fortsätta."
 
 #. MSG_PRINT_ABORTED c=20
-#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:780
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:782
 msgid "Print aborted"
 msgstr "Utskriften avbröts"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1078
-#: ../../Firmware/ultralcd.cpp:6898
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1080
+#: ../../Firmware/ultralcd.cpp:6879
 msgid "Print fan:"
 msgstr "Utskriftsfläkt:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5255
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5249
 msgid "Print from SD"
 msgstr "Skriv ut från SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/ultralcd.cpp:794
+#: ../../Firmware/ultralcd.cpp:796
 msgid "Print paused"
 msgstr "Utskriften pausad"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2320
+#: ../../Firmware/ultralcd.cpp:2324
 msgid "Print time"
 msgstr "Utskriftstid"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1661
+#: ../../Firmware/ultralcd.cpp:1665
 msgid "Printer IP Addr:"
 msgstr "Skrivarens IP adr:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1543 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1548 ../../Firmware/messages.cpp:42
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1693,12 +1689,12 @@ msgstr ""
 "stegen, avsnitt Kalibreringsflöde."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:143 ../../Firmware/util.cpp:293
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Munstycksdiametern skiljer sig från G-codeen. Fortsätta?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:144 ../../Firmware/util.cpp:294
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1707,7 +1703,7 @@ msgstr ""
 "inställningarna. Utskriften avbröts."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
+#: ../../Firmware/mmu2/errors_list.h:245 ../../Firmware/mmu2/errors_list.h:301
 msgid "Pulley motor stalled. Ensure the pulley can move and check the wiring."
 msgstr ""
 "Remskivans motor stannade. Se till att remskivan kan röra sig och "
@@ -1720,32 +1716,32 @@ msgid "Pushing filament"
 msgstr "Pressar filament"
 
 #. MSG_TITLE_QUEUE_FULL c=20
-#: ../../Firmware/mmu2/errors_list.h:184 ../../Firmware/mmu2/errors_list.h:231
+#: ../../Firmware/mmu2/errors_list.h:183 ../../Firmware/mmu2/errors_list.h:230
 msgid "QUEUE FULL"
 msgstr "KÖ FULL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2684
+#: ../../Firmware/ultralcd.cpp:2688
 msgid "Rear side [µm]"
 msgstr "Baksida [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/power_panic.cpp:323
+#: ../../Firmware/power_panic.cpp:322
 msgid "Recovering print"
 msgstr "Återställer utskrift"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5122
+#: ../../Firmware/ultralcd.cpp:5135
 msgid "Rename"
 msgstr "Döp om"
 
 #. MSG_DESC_INVALID_TOOL c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:335
+#: ../../Firmware/mmu2/errors_list.h:280 ../../Firmware/mmu2/errors_list.h:334
 msgid ""
 "Requested filament tool is not available on this hardware. Check the G-code "
 "for tool index out of range (T0-T4)."
@@ -1754,24 +1750,24 @@ msgstr ""
 "G-codeen för verktygsindex utanför intervallet (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:2685
-#: ../../Firmware/ultralcd.cpp:5123
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:2689
+#: ../../Firmware/ultralcd.cpp:5136
 msgid "Reset"
 msgstr "Återställ"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4577
+#: ../../Firmware/ultralcd.cpp:4590
 msgid "Reset XYZ calibr."
 msgstr "Återställ XYZ-kal."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:617 ../../Firmware/messages.cpp:90
-#: ../../Firmware/ultralcd.cpp:5228 ../../Firmware/ultralcd.cpp:5230
+#: ../../Firmware/Marlin_main.cpp:621 ../../Firmware/messages.cpp:86
+#: ../../Firmware/ultralcd.cpp:5230 ../../Firmware/ultralcd.cpp:5232
 msgid "Resume print"
 msgstr "Återuppta utskrift"
 
 #. MSG_RESUMING_PRINT c=20
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:611
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:612
 msgid "Resuming print"
 msgstr "Återupptar utskrift"
 
@@ -1782,7 +1778,7 @@ msgid "Retract from FINDA"
 msgstr "Dra in från FINDA"
 
 #. MSG_BTN_RETRY c=8
-#: ../../Firmware/mmu2/errors_list.h:353 ../../Firmware/mmu2/errors_list.h:366
+#: ../../Firmware/mmu2/errors_list.h:352 ../../Firmware/mmu2/errors_list.h:365
 msgid "Retry"
 msgstr "Igen"
 
@@ -1793,17 +1789,17 @@ msgid "Returning selector"
 msgstr "Återvändande väljare"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2451
+#: ../../Firmware/ultralcd.cpp:2455
 msgid "Right"
 msgstr "Höger"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2682
+#: ../../Firmware/ultralcd.cpp:2686
 msgid "Right side[µm]"
 msgstr "Höger sida[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3642
+#: ../../Firmware/ultralcd.cpp:3653
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1812,39 +1808,39 @@ msgstr ""
 "börja om från början. Fortsätta?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4492
-#: ../../Firmware/ultralcd.cpp:4494
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4503
+#: ../../Firmware/ultralcd.cpp:4505
 msgid "SD card"
 msgstr "SD-kort"
 
 #. MSG_TITLE_SELECTOR_CANNOT_HOME c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:201
+#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:200
 msgid "SELECTOR CANNOT HOME"
 msgstr "VÄLJARE FASTNAT"
 
 #. MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
-#: ../../Firmware/mmu2/errors_list.h:147 ../../Firmware/mmu2/errors_list.h:202
+#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:201
 msgid "SELECTOR CANNOT MOVE"
 msgstr "VÄLJARE FASTNAT"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9522 ../../Firmware/messages.cpp:119
+#: ../../Firmware/Marlin_main.cpp:9612 ../../Firmware/messages.cpp:115
 msgid "STOPPED."
 msgstr "STOPPAD."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3159 ../../Firmware/Marlin_main.cpp:3181
-#: ../../Firmware/mesh_bed_calibration.cpp:2249 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:3250 ../../Firmware/Marlin_main.cpp:3272
+#: ../../Firmware/mesh_bed_calibration.cpp:2239 ../../Firmware/messages.cpp:40
 msgid "Searching bed calibration point"
 msgstr "Söker efter kalibreringspunkt för bädden"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5115
+#: ../../Firmware/ultralcd.cpp:5128
 msgid "Select"
 msgstr "Välj"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3716
+#: ../../Firmware/ultralcd.cpp:3727
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1852,25 +1848,25 @@ msgstr ""
 "Välj ett filament för första lagrets kalibrering och välj det i skärmmenyn."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3392 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3598
-#: ../../Firmware/ultralcd.cpp:6726
+#: ../../Firmware/Marlin_main.cpp:3483 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:3609
+#: ../../Firmware/ultralcd.cpp:6709
 msgid "Select filament:"
 msgstr "Välj filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3450
-#: ../../Firmware/ultralcd.cpp:4487
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:3461
+#: ../../Firmware/ultralcd.cpp:4498
 msgid "Select language"
 msgstr "Välj språk"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3886
+#: ../../Firmware/ultralcd.cpp:3897
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Välj munstycksförvärmningstemperatur som passar ditt material."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3721
+#: ../../Firmware/ultralcd.cpp:3732
 msgid "Select temperature which matches your material."
 msgstr "Välj temperatur som passar ditt material."
 
@@ -1881,73 +1877,73 @@ msgid "Selecting fil. slot"
 msgstr "Välj fil. spår"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6178
+#: ../../Firmware/ultralcd.cpp:6161
 msgid "Self test OK"
 msgstr "Självtest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:5961
+#: ../../Firmware/ultralcd.cpp:5944
 msgid "Self test start"
 msgstr "Självteststart"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4564
+#: ../../Firmware/ultralcd.cpp:4577
 msgid "Selftest"
 msgstr "Självtest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6603
+#: ../../Firmware/ultralcd.cpp:6586
 msgid "Selftest error!"
 msgstr "Självtestfel!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6183
-#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6888
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:6166
+#: ../../Firmware/ultralcd.cpp:6673 ../../Firmware/ultralcd.cpp:6869
 msgid "Selftest failed"
 msgstr "Självtestet felade"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1518
+#: ../../Firmware/Marlin_main.cpp:1523
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Självtest kommer att utföras för att kalibrera exakt sensorlös hemposition."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1673
+#: ../../Firmware/ultralcd.cpp:1677
 msgid "Sensor info"
 msgstr "Sensorinfo"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:5931
+#: ../../Firmware/ultralcd.cpp:5914
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verifierad, ta bort filamentet nu."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2702
+#: ../../Firmware/ultralcd.cpp:2706
 msgid "Set temperature:"
 msgstr "Sätt temperatur:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:3322
-#: ../../Firmware/ultralcd.cpp:3465 ../../Firmware/ultralcd.cpp:3970
-#: ../../Firmware/ultralcd.cpp:5306 ../../Firmware/ultralcd.cpp:5519
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3476 ../../Firmware/ultralcd.cpp:3981
+#: ../../Firmware/ultralcd.cpp:5301 ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5548
 msgid "Settings"
 msgstr "Inställningar"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2498
 msgid "Severe skew"
 msgstr "Hög skevhet"
 
 #. MSG_SHEET c=10
 #: ../../Firmware/menu.cpp:195 ../../Firmware/menu.cpp:207
-#: ../../Firmware/messages.cpp:68
+#: ../../Firmware/messages.cpp:64
 msgid "Sheet"
 msgstr "Skiva"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3590
+#: ../../Firmware/ultralcd.cpp:3601
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1960,23 +1956,23 @@ msgstr ""
 "%cÅterställ"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4575
+#: ../../Firmware/ultralcd.cpp:4588
 msgid "Show end stops"
 msgstr "Visa ändlägen"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8196 ../../Firmware/messages.cpp:114
-#: ../../Firmware/ultralcd.cpp:4138 ../../Firmware/ultralcd.cpp:4177
+#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:4149
+#: ../../Firmware/ultralcd.cpp:4188
 msgid "Silent"
 msgstr "Tyst"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2493
+#: ../../Firmware/ultralcd.cpp:2497
 msgid "Slight skew"
 msgstr "Låg skevhet"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:815
+#: ../../Firmware/cardreader.cpp:814
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1985,125 +1981,125 @@ msgstr ""
 "sortering är 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2978
+#: ../../Firmware/Marlin_main.cpp:3041
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Ett problem har uppstått, Z-nivellering utförs..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4497
-#: ../../Firmware/ultralcd.cpp:4498 ../../Firmware/ultralcd.cpp:4499
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4508
+#: ../../Firmware/ultralcd.cpp:4509 ../../Firmware/ultralcd.cpp:4510
 msgid "Sort"
 msgstr "Sortera"
 
 #. MSG_SORTING_FILES c=20
-#: ../../Firmware/cardreader.cpp:859 ../../Firmware/cardreader.cpp:926
-#: ../../Firmware/messages.cpp:105
+#: ../../Firmware/cardreader.cpp:858 ../../Firmware/cardreader.cpp:925
+#: ../../Firmware/messages.cpp:101
 msgid "Sorting files"
 msgstr "Sorterar filer"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4174 ../../Firmware/ultralcd.cpp:4177
-#: ../../Firmware/ultralcd.cpp:4180 ../../Firmware/ultralcd.cpp:4183
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4182
+#: ../../Firmware/ultralcd.cpp:4185 ../../Firmware/ultralcd.cpp:4188
+#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
 msgid "Sound"
 msgstr "Ljud"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5450
+#: ../../Firmware/ultralcd.cpp:5436
 msgid "Speed"
 msgstr "Fart"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6765
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6748
 msgid "Spinning"
 msgstr "Rotation"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4654
+#: ../../Firmware/Marlin_main.cpp:4745
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabil omgivningstemperatur 21-26C krävs samt ett styvt stativ."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5311
+#: ../../Firmware/ultralcd.cpp:5306
 msgid "Statistics"
 msgstr "Statistik"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:4082
-#: ../../Firmware/ultralcd.cpp:4127
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:4093
+#: ../../Firmware/ultralcd.cpp:4138
 msgid "Stealth"
 msgstr "Tyst"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4404
-#: ../../Firmware/ultralcd.cpp:5112
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:4415
+#: ../../Firmware/ultralcd.cpp:5125
 msgid "Steel sheets"
 msgstr "Metallskivor"
 
 #. MSG_BTN_STOP c=8
-#: ../../Firmware/mmu2/errors_list.h:360 ../../Firmware/mmu2/errors_list.h:373
+#: ../../Firmware/mmu2/errors_list.h:359 ../../Firmware/mmu2/errors_list.h:372
 msgid "Stop"
 msgstr "Stopp"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5235
-#: ../../Firmware/ultralcd.cpp:5685
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5668
 msgid "Stop print"
 msgstr "Stoppa utskriften"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4219
-#: ../../Firmware/ultralcd.cpp:4299 ../../Firmware/ultralcd.cpp:4338
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4230
+#: ../../Firmware/ultralcd.cpp:4310 ../../Firmware/ultralcd.cpp:4349
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5320
+#: ../../Firmware/ultralcd.cpp:5315
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:6662
+#: ../../Firmware/ultralcd.cpp:6645
 msgid "Swapped"
 msgstr "Utbytt"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:182 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:178 ../../Firmware/temperature.cpp:2222
 msgid "THERMAL ANOMALY"
 msgstr "TERMISK ANOMALI"
 
 #. MSG_TITLE_TMC_DRIVER_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:159 ../../Firmware/mmu2/errors_list.h:211
-#: ../../Firmware/mmu2/errors_list.h:212 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:158 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:212
 msgid "TMC DRIVER ERROR"
 msgstr "TMC DRIVER FEL"
 
 #. MSG_TITLE_TMC_DRIVER_RESET c=20
-#: ../../Firmware/mmu2/errors_list.h:163 ../../Firmware/mmu2/errors_list.h:214
-#: ../../Firmware/mmu2/errors_list.h:215 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:162 ../../Firmware/mmu2/errors_list.h:213
+#: ../../Firmware/mmu2/errors_list.h:214 ../../Firmware/mmu2/errors_list.h:215
 msgid "TMC DRIVER RESET"
 msgstr "TMC DRIVER RESET"
 
 #. MSG_TITLE_TMC_DRIVER_SHORTED c=20
-#: ../../Firmware/mmu2/errors_list.h:171 ../../Firmware/mmu2/errors_list.h:220
-#: ../../Firmware/mmu2/errors_list.h:221 ../../Firmware/mmu2/errors_list.h:222
+#: ../../Firmware/mmu2/errors_list.h:170 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "TMC DRIVER SHORTED"
 msgstr "TMC DRIVER KORTSLUTN"
 
 #. MSG_TITLE_TMC_OVERHEAT_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:155 ../../Firmware/mmu2/errors_list.h:208
-#: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:210
+#: ../../Firmware/mmu2/errors_list.h:154 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:209
 msgid "TMC OVERHEAT ERROR"
 msgstr "TMC ÖVERHETTNINGSFEL"
 
 #. MSG_TITLE_TMC_UNDERVOLTAGE_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:167 ../../Firmware/mmu2/errors_list.h:217
-#: ../../Firmware/mmu2/errors_list.h:218 ../../Firmware/mmu2/errors_list.h:219
+#: ../../Firmware/mmu2/errors_list.h:166 ../../Firmware/mmu2/errors_list.h:216
+#: ../../Firmware/mmu2/errors_list.h:217 ../../Firmware/mmu2/errors_list.h:218
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERSPÄNNINGFEL"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3867
+#: ../../Firmware/ultralcd.cpp:3878
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2112,27 +2108,27 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Marlin_main.cpp:1559 ../../Firmware/messages.cpp:179
 msgid "Thermal model not calibrated yet."
 msgstr "Termisk-modellen är inte kalibrerad ännu."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4438
+#: ../../Firmware/ultralcd.cpp:4449
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1679
+#: ../../Firmware/ultralcd.cpp:1683
 msgid "Temperatures"
 msgstr "Temperaturer"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:374
+#: ../../Firmware/messages.cpp:59 ../../Firmware/mmu2_reporting.cpp:356
 msgid "Testing filament"
 msgstr "Testar filament"
 
 #. MSG_DESC_IDLER_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:253 ../../Firmware/mmu2/errors_list.h:308
+#: ../../Firmware/mmu2/errors_list.h:252 ../../Firmware/mmu2/errors_list.h:307
 msgid ""
 "The Idler cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2140,7 +2136,7 @@ msgstr ""
 "blockerar dess rörelse."
 
 #. MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:250 ../../Firmware/mmu2/errors_list.h:306
+#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
 msgid ""
 "The Selector cannot home properly. Check for anything blocking its movement."
 msgstr ""
@@ -2148,7 +2144,7 @@ msgstr ""
 "blockerar dess rörelse."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3724
+#: ../../Firmware/ultralcd.cpp:3735
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2158,7 +2154,7 @@ msgstr ""
 "optimal höjd. Kontrollera med bilderna i handboken (Kalibreringskapitlet)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1547 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1552 ../../Firmware/messages.cpp:43
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2167,63 +2163,63 @@ msgstr ""
 "kap Första stegen, avs Kalibreringsflöde."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:4497
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4508
 msgid "Time"
 msgstr "Tid"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:5556
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5539
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:1101
-#: ../../Firmware/ultralcd.cpp:1259
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:1103
+#: ../../Firmware/ultralcd.cpp:1261
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1203 ../../Firmware/ultralcd.cpp:1289
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:1151
+#: ../../Firmware/ultralcd.cpp:1205 ../../Firmware/ultralcd.cpp:1291
 msgid "Total failures"
 msgstr "Totala fel"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2341
+#: ../../Firmware/ultralcd.cpp:2345
 msgid "Total filament"
 msgstr "Total filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2342
+#: ../../Firmware/ultralcd.cpp:2346
 msgid "Total print time"
 msgstr "Tot utskriftstid"
 
-#. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:110 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5207
+#. MSG_BTN_TUNE_MMU c=8
+#: ../../Firmware/messages.cpp:106 ../../Firmware/mmu2/errors_list.h:358
+#: ../../Firmware/mmu2/errors_list.h:371 ../../Firmware/ultralcd.cpp:5209
 msgid "Tune"
 msgstr "Ställ in"
 
 #. MSG_TITLE_UNLOAD_MANUALLY c=20
-#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
+#: ../../Firmware/mmu2/errors_list.h:186 ../../Firmware/mmu2/errors_list.h:233
 msgid "UNLOAD MANUALLY"
 msgstr "LADDA UR MANUELLT"
 
 #. MSG_BTN_UNLOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
+#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
 msgid "Unload"
 msgstr "Ladda ur"
 
 #. MSG_UNLOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:5287
-#: ../../Firmware/ultralcd.cpp:5304
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
+#: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"
 msgstr "Ta bort filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3375 ../../Firmware/messages.cpp:123
+#: ../../Firmware/Marlin_main.cpp:3466 ../../Firmware/messages.cpp:119
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4894
+#: ../../Firmware/ultralcd.cpp:4907
 msgid "Unloading filament"
 msgstr "Tar bort filament"
 
@@ -2240,23 +2236,23 @@ msgid "Unloading to pulley"
 msgstr "Ladd ur t. remskiva"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:5934
+#: ../../Firmware/ultralcd.cpp:5917
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifieringen felade, ta bort filamentet, försök igen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1682
+#: ../../Firmware/ultralcd.cpp:1686
 msgid "Voltages"
 msgstr "Spänning"
 
 #. MSG_TITLE_TMC_WARNING_TMC_TOO_HOT c=20
-#: ../../Firmware/mmu2/errors_list.h:151 ../../Firmware/mmu2/errors_list.h:205
-#: ../../Firmware/mmu2/errors_list.h:206 ../../Firmware/mmu2/errors_list.h:207
+#: ../../Firmware/mmu2/errors_list.h:150 ../../Firmware/mmu2/errors_list.h:204
+#: ../../Firmware/mmu2/errors_list.h:205 ../../Firmware/mmu2/errors_list.h:206
 msgid "WARNING TMC TOO HOT"
 msgstr "VARNING TMC FÖR VARM"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3365
+#: ../../Firmware/ultralcd.cpp:3376
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2269,190 +2265,196 @@ msgstr ""
 "tyst-läge"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5150
+#: ../../Firmware/Marlin_main.cpp:5260
 msgid "Wait for user..."
 msgstr "Väntar på användare."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2726
+#: ../../Firmware/ultralcd.cpp:2730
 msgid "Waiting for PINDA probe cooling"
 msgstr "Väntar på PINDA-sondens kylning"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2756
+#: ../../Firmware/ultralcd.cpp:2760
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Väntar på munstycks- och bäddkylning"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4216
-#: ../../Firmware/ultralcd.cpp:4296 ../../Firmware/ultralcd.cpp:4335
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4227
+#: ../../Firmware/ultralcd.cpp:4307 ../../Firmware/ultralcd.cpp:4346
 msgid "Warn"
 msgstr "Varna"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1495
+#: ../../Firmware/Marlin_main.cpp:1500
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Varning: både skrivartyp och moderkortstyp har ändrats."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1487
+#: ../../Firmware/Marlin_main.cpp:1492
 msgid "Warning: motherboard type changed."
 msgstr "Varning: moderkortstyp ändrad."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1491
+#: ../../Firmware/Marlin_main.cpp:1496
 msgid "Warning: printer type changed."
 msgstr "Varning: skrivartyp ändrats."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3455
+#: ../../Firmware/Marlin_main.cpp:3546
 msgid "Was filament unload successful?"
 msgstr "Lyckades filamentutmatningen?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6614
-#: ../../Firmware/ultralcd.cpp:6618 ../../Firmware/ultralcd.cpp:6638
-#: ../../Firmware/ultralcd.cpp:6644 ../../Firmware/ultralcd.cpp:6668
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6597
+#: ../../Firmware/ultralcd.cpp:6601 ../../Firmware/ultralcd.cpp:6621
+#: ../../Firmware/ultralcd.cpp:6627 ../../Firmware/ultralcd.cpp:6651
 msgid "Wiring error"
 msgstr "Kabelfel"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4555
+#: ../../Firmware/ultralcd.cpp:4568
 msgid "Wizard"
 msgstr "Guide"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3972
+#: ../../Firmware/ultralcd.cpp:3983
 msgid "X-correct"
 msgstr "X-korrektion"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1671
+#: ../../Firmware/ultralcd.cpp:1675
 msgid "XYZ cal. details"
 msgstr "XYZ kal. detaljer"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3181
+#: ../../Firmware/ultralcd.cpp:3192
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ-kalibrering ok. Skevhet kommer att korrigeras automatiskt."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3178
+#: ../../Firmware/ultralcd.cpp:3189
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ-kalibrering ok. X/Y-axlarna är mycket lite skeva. Bra jobbat!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3159
+#: ../../Firmware/ultralcd.cpp:3170
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ-kalibrering komprometterad. Främre kalibreringspunkt kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3162
+#: ../../Firmware/ultralcd.cpp:3173
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-kalibrering komprometterad. Främre hö kalibreringspunkter kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3141
+#: ../../Firmware/ultralcd.cpp:3152
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-kalibrering felade. Kalibreringspunkter ej funna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3147
+#: ../../Firmware/ultralcd.cpp:3158
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ-kalibrering felade. Främre kalibreringspunkt kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3144
-#: ../../Firmware/ultralcd.cpp:3172
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3155
+#: ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-kalibrering felade. Se bruksanvisningen."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3150
+#: ../../Firmware/ultralcd.cpp:3161
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ-kalibrering felade. Höger främre kalibreringspunkt kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3175
+#: ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-kalibrering ok. X/Y-axlarna ar vinkelräta. Grattis!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2448
+#: ../../Firmware/ultralcd.cpp:2452
 msgid "Y distance from min"
 msgstr "Y avstånd från min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3973
+#: ../../Firmware/ultralcd.cpp:3984
 msgid "Y-correct"
 msgstr "Y-korrekt"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:2176
-#: ../../Firmware/ultralcd.cpp:3003 ../../Firmware/ultralcd.cpp:4426
-#: ../../Firmware/ultralcd.cpp:4514 ../../Firmware/ultralcd.cpp:5694
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:2180
+#: ../../Firmware/ultralcd.cpp:3012 ../../Firmware/ultralcd.cpp:4437
+#: ../../Firmware/ultralcd.cpp:4525 ../../Firmware/ultralcd.cpp:5677
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3936
+#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:3947
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Du kan alltid återuppta guiden från Kalibrering -> Guide."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3985
 msgid "Z-correct"
 msgstr "Z-korrekt"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:5527
+#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:5510
 msgid "Z-probe nr."
 msgstr "Z-sond nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2518
+#: ../../Firmware/ultralcd.cpp:2522
 msgid "[0;0] point offset"
 msgstr "[0;0] punktförskjutn"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2119
+#: ../../Firmware/ultralcd.cpp:2123
 msgid "and press the knob"
 msgstr "och tryck på knapp"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1779
+#: ../../Firmware/ultralcd.cpp:1783
 msgid "to load filament"
 msgstr "att ladda filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1783
+#: ../../Firmware/ultralcd.cpp:1787
 msgid "to unload filament"
 msgstr "att ta bort filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1638
+#: ../../Firmware/ultralcd.cpp:1642
 msgid "unknown"
 msgstr "okänd"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:178
+#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:174
 msgid "unknown state"
 msgstr "okänt stat"
 
+#. MSG_REFRESH c=18
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5748
+msgid "🔃Refresh"
+msgstr "🔃Uppdatera"
+
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1152
+#: ../../Firmware/messages.cpp:70 ../../Firmware/ultralcd.cpp:1154
 msgid "MMU power fails"
 msgstr "MMU strömavbr."
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
-#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+#: ../../Firmware/mmu2/errors_list.h:187 ../../Firmware/mmu2/errors_list.h:234
 msgid "FILAMENT EJECTED"
 msgstr "FILAMENT UTASTAT"
 
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
+#: ../../Firmware/mmu2/errors_list.h:283 ../../Firmware/mmu2/errors_list.h:338
 msgid ""
 "Filament detected unexpectedly. Ensure no filament is loaded. Check the "
 "sensors and wiring."
@@ -2461,12 +2463,12 @@ msgstr ""
 "Kontrollera sensorerna och kablarna."
 
 #. MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
-#: ../../Firmware/mmu2/errors_list.h:146 ../../Firmware/mmu2/errors_list.h:200
+#: ../../Firmware/mmu2/errors_list.h:145 ../../Firmware/mmu2/errors_list.h:199
 msgid "LOAD TO EXTR. FAILED"
 msgstr "MISLUKT LADDA EXTR."
 
 #. MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:249 ../../Firmware/mmu2/errors_list.h:305
+#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
 msgid ""
 "Loading to extruder failed. Inspect the filament tip shape. Refine the "
 "sensor calibration, if needed."
@@ -2475,28 +2477,28 @@ msgstr ""
 "Förfina sensorkalibreringen vid behov."
 
 #. MSG_TITLE_MMU_MCU_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:226
+#: ../../Firmware/mmu2/errors_list.h:178 ../../Firmware/mmu2/errors_list.h:225
 msgid "MMU MCU ERROR"
 msgstr "MMU MCU FEL"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:1102
-#: ../../Firmware/ultralcd.cpp:1176
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1104
+#: ../../Firmware/ultralcd.cpp:1178
 msgid "Material changes"
 msgstr "Materialutbyten"
 
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+#: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid "Remove the ejected filament from the front of the MMU."
 msgstr "Ta bort den utskjutna filament från framsidan av MMU."
 
 #. MSG_BTN_RESET_MMU c=8
-#: ../../Firmware/mmu2/errors_list.h:355 ../../Firmware/mmu2/errors_list.h:368
+#: ../../Firmware/mmu2/errors_list.h:354 ../../Firmware/mmu2/errors_list.h:367
 msgid "ResetMMU"
 msgstr "ResetMMU"
 
 #. MSG_DESC_INSPECT_FINDA c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:248 ../../Firmware/mmu2/errors_list.h:304
+#: ../../Firmware/mmu2/errors_list.h:247 ../../Firmware/mmu2/errors_list.h:303
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
 " is in Selector and FINDA works properly."
@@ -2505,7 +2507,7 @@ msgstr ""
 "till att inget glödtråd är i väljaren och att FINDA fungerar korrekt."
 
 #. MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:290 ../../Firmware/mmu2/errors_list.h:337
+#: ../../Firmware/mmu2/errors_list.h:289 ../../Firmware/mmu2/errors_list.h:336
 msgid ""
 "MMU FW version is incompatible with printer FW.Update to version 3.0.1."
 msgstr ""
@@ -2513,47 +2515,55 @@ msgstr ""
 "version 3.0.1."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5284
+#: ../../Firmware/messages.cpp:55 ../../Firmware/ultralcd.cpp:5279
 msgid "Preload to MMU"
 msgstr "Förladdning MMU"
 
+#. MSG_FW_MK3_DETECTED c=20 r=4
+msgid "MK3 firmware detected on MK3S printer"
+msgstr "MK3-firmware upptäckt på MK3S-skrivare"
+
+#. MSG_FW_MK3S_DETECTED c=20 r=4
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "MK3S-firmware upptäckt på MK3-skrivare"
+
 #. MSG_TITLE_UNKNOWN_ERROR c=20
-#: ../../Firmware/mmu2/errors_list.h:190 ../../Firmware/mmu2/errors_list.h:237
+#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
 msgid "UNKNOWN ERROR"
 msgstr "OKÄNT FEL"
 
 #. MSG_DESC_UNKNOWN_ERROR c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:287 ../../Firmware/mmu2/errors_list.h:342
+#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
 msgid "Unexpected error occurred."
 msgstr "Ett oväntat fel inträffade."
 
 #. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
 msgid "Eject"
 msgstr "Mata ut"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
-#: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
 msgstr "FILAMENTBYTE"
 
 #. MSG_BTN_LOAD c=8
-#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:370
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:369
 msgid "Load"
 msgstr "Ladda"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:286 ../../Firmware/mmu2/errors_list.h:341
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "M600 filamentbyte. Ladda en ny filament eller mata ut den gamla."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/mmu2_reporting.cpp:444
+#: ../../Firmware/mmu2_reporting.cpp:426
 msgid "Sensitivity"
 msgstr "Känslighet"
 
 #. MSG_MBL_FAILED_Z_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:2973
+#: ../../Firmware/Marlin_main.cpp:2976
 msgid "Mesh bed leveling failed. Please run Z calibration."
 msgstr "Bäddnivelleringen felade. Kör Z-kalibrering."
 
@@ -2570,16 +2580,7 @@ msgstr "Set inte klart"
 #. MSG_REPRINT c=18
 #: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5191
 msgid "Reprint"
-msgstr "Omtryck"
-
-#~ msgid "🔃Refresh"
-#~ msgstr "🔃Uppdatera"
-
-#~ msgid "MK3 firmware detected on MK3S printer"
-#~ msgstr "MK3-firmware upptäckt på MK3S-skrivare"
-
-#~ msgid "MK3S firmware detected on MK3 printer"
-#~ msgstr "MK3S-firmware upptäckt på MK3-skrivare"
+msgstr "Upprepa trycket"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamla fil. och tryck på knappen för att börja ladda nytt."


### PR DESCRIPTION
Sorry this PR is rebased to MK3 only commit needed is.

[Set YES as default in Crash Resume message](https://github.com/gudnimg/Prusa-Firmware/pull/5/commits/5dbc84784201efba72a1405e37243199fe1c354c)
